### PR TITLE
[PR](Memory allocation): Fixed memory allocation check and free

### DIFF
--- a/src/Server/free.c
+++ b/src/Server/free.c
@@ -106,7 +106,7 @@ static void free_map(server_t *server, parsing_info_t *parsed_info)
     server->current_resources = NULL;
 }
 
-static void free_parsed_info_contents(parsing_info_t *p_info)
+static void free_parsed_info(parsing_info_t *p_info)
 {
     if (!p_info || !p_info->names)
         return;
@@ -126,5 +126,7 @@ void free_all(server_t *server, parsing_info_t *parsed_info)
     free_eggs(server);
     free_map(server, parsed_info);
     if (parsed_info)
-        free_parsed_info_contents(parsed_info);
+        free_parsed_info(parsed_info);
+    if (server->parsed_info)
+        free_parsed_info(server->parsed_info);
 }

--- a/src/Server/map/egg.c
+++ b/src/Server/map/egg.c
@@ -22,6 +22,8 @@ egg_t *create_egg(int egg_id, int pos_x, int pos_y, char *team)
     new_egg->pos_y = pos_y;
     new_egg->next = NULL;
     new_egg->team_name = strdup(team);
+    if (new_egg->team_name == NULL)
+        server_err("Egg team allocation failed\n");
     return new_egg;
 }
 


### PR DESCRIPTION
This pull request refactors memory management functions and adds error handling for egg creation in the server codebase. The most important changes include renaming and consolidating functions for freeing resources, improving cleanup logic, and adding a safeguard for memory allocation failures.

### Memory management improvements:

* [`src/Server/free.c`](diffhunk://#diff-f23cc916d3b9f2a48af549d46d17c55afb414c0b6807657857deb816360726c2L109-R109): Renamed `free_parsed_info_contents` to `free_parsed_info` for clarity and consolidated its usage in both `free_map` and `free_all` functions. Added a check to free `server->parsed_info` in `free_all` to ensure proper cleanup. [[1]](diffhunk://#diff-f23cc916d3b9f2a48af549d46d17c55afb414c0b6807657857deb816360726c2L109-R109) [[2]](diffhunk://#diff-f23cc916d3b9f2a48af549d46d17c55afb414c0b6807657857deb816360726c2L129-R131)

### Error handling enhancements:

* [`src/Server/map/egg.c`](diffhunk://#diff-b3fa31cea141956d973e7261766b8af0105c1f062b04fee2d281a195bd736308R25-R26): Added error handling in `create_egg` to log an error message if memory allocation for `team_name` fails.