### PR TITLE
[PR] pull request for issue #38 protocol implémenter la commande mct contenu complet de la map

### DIFF
--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -30,14 +30,14 @@ command_data_t get_command_data(void)
 {
     static const char *comm_char[] = {"Forward", "Right", "Left",
         "Inventory", "Look", "Eject", "Connect_nbr", "Take", "Set",
-        "Incantation", "Fork", "Broadcast", "msz", "bct", NULL};
+        "Incantation", "Fork", "Broadcast", "msz", "bct", "mtc", NULL};
     static void (*comm_func[])(server_t *, client_t *, char *) =
         {forward, right, left, inventory, look, eject,
         connect_nbr, take_object, set_object, start_incantation,
-        fork_c, broadcast, command_msz, command_bct, NULL};
-    static int comm_times[] = {7, 7, 7, 1, 7, 7, 0, 7, 7, 300, 42, 7, 0, 0};
+        fork_c, broadcast, command_msz, command_bct, command_mtc, NULL};
+    static int comm_times[] = {7, 7, 7, 1, 7, 7, 0, 7, 7, 300, 42, 7, 0, 0, 0};
     static enum client_type_e accepted_types[] = {AI, AI, AI, AI, AI,
-        AI, AI, AI, AI, AI, AI, AI, GRAPHICAL, GRAPHICAL};
+        AI, AI, AI, AI, AI, AI, AI, GRAPHICAL, GRAPHICAL, GRAPHICAL};
     command_data_t data = {comm_char, comm_func, comm_times, accepted_types};
 
     return data;

--- a/src/Server/graphical_command/command_bct.c
+++ b/src/Server/graphical_command/command_bct.c
@@ -89,3 +89,13 @@ void command_bct(server_t *server, client_t *client, char *buffer)
         return write_command_output(client->client_fd, "ko\n");
     send_bct_command(server, client, x, y);
 }
+
+void command_mtc(server_t *server, client_t *client, char *buffer)
+{
+    (void)buffer;
+    if (!server || !client)
+        return;
+    if (client->type != GRAPHICAL)
+        return write_command_output(client->client_fd, "ko\n");
+    send_tile_content_to_one_client(server, client);
+}

--- a/src/Server/include/command.h
+++ b/src/Server/include/command.h
@@ -54,5 +54,6 @@ char *check_rota_tiles(client_t *user, server_t *server, int i, int j);
 // client graphical commands
 void command_msz(server_t *server, client_t *client, char *buffer);
 void command_bct(server_t *server, client_t *client, char *buffer);
+void command_mtc(server_t *server, client_t *client, char *buffer);
 
 #endif /* !COMMAND_H_ */


### PR DESCRIPTION
This pull request introduces new graphical commands (`bct` and `mtc`) and refactors parts of the server's graphical client management. The most significant changes include adding support for the new commands, updating the command parsing logic, and improving the `remove_graphical_node` function to fix pointer handling. Below is a breakdown of the key changes:

### New Graphical Commands

* Added `command_bct` to handle the `bct` command, which retrieves tile content for specified coordinates. Includes input validation and integration with the `send_bct_command` function. (`[src/Server/graphical_command/command_bct.cR73-R101](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefR73-R101)`)
* Added `command_mtc` to handle the `mtc` command, which sends the content of all tiles to a graphical client. (`[src/Server/graphical_command/command_bct.cR73-R101](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefR73-R101)`)
* Updated `command.h` to declare the new graphical commands (`command_bct` and `command_mtc`). (`[src/Server/include/command.hR56-R57](diffhunk://#diff-6855e26a3858c9911bdc01ebbc1491a1644486d0149fa095cd766ef9ba70533fR56-R57)`)

### Command Parsing Updates

* Extended the `comm_char`, `comm_func`, `comm_times`, and `accepted_types` arrays in `get_command_data` to include the new `bct` and `mtc` commands. (`[src/Server/command/parse_command.cL33-R40](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L33-R40)`)

### Graphical Client Management Refactor

* Refactored `remove_graphical_node` to use double pointers for safer pointer manipulation and to return a `bool` indicating whether the node was removed. (`[src/Server/network/graphical_client.cL41-R54](diffhunk://#diff-e1677f83393b19bde8e6e91eeb698c3b1750aefbfb7b2957c3f856fbd468a40fL41-R54)`)
* Updated `remove_graphic_client` to handle the updated `remove_graphical_node` logic, ensuring proper traversal and early exit upon node removal. (`[src/Server/network/graphical_client.cL64-R66](diffhunk://#diff-e1677f83393b19bde8e6e91eeb698c3b1750aefbfb7b2957c3f856fbd468a40fL64-R66)`)

### Miscellaneous Improvements

* Removed unused test code comments from `find_and_execute` function. (`[src/Server/command/parse_command.cL91-L94](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L91-L94)`)
* Added missing `#include <string.h>` in `command_bct.c` for string manipulation functions. (`[src/Server/graphical_command/command_bct.cR14](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefR14)`)
* Removed debug `printf` statement from `command_msz` function to clean up logging. (`[src/Server/graphical_command/command_msz.cL36](diffhunk://#diff-9b1c48e2e18a06c742a55255fdbbbaf5a202513a2271547399392d27ef3e46feL36)`)