### PR TITLE
[FEAT](Win condition): Added win condition for Zappy project

### DIFF
--- a/src/Server/command/finish_incantation.c
+++ b/src/Server/command/finish_incantation.c
@@ -36,8 +36,30 @@ static bool remove_resources(tile_t *tile, int level)
     return true;
 }
 
+//? This is the function that needs to send the winner team's name
+static void handle_win(char *winner, server_t *server)
+{
+    server->should_run = false;
+    printf("%s team are the winner of this Zappy tournament\n", winner);
+}
+
+static void check_win(client_t *client, server_t *server)
+{
+    int count = 0;
+    char *team_name = client->player->team_name;
+    client_t *temp = server->client;
+
+    while (temp){
+        if (temp->player && temp->player->level == 8 &&
+            strcmp(temp->player->team_name, team_name) == 0)
+            count++;
+    }
+    if (count >= 6)
+        handle_win(team_name, server);
+}
+
 static void handle_incantation_success(client_t *client,
-    tile_t *tile, int old_level)
+    tile_t *tile, int old_level, server_t *server)
 {
     char *level_str;
 
@@ -49,6 +71,8 @@ static void handle_incantation_success(client_t *client,
     sprintf(level_str, "Current level: %d\n", client->player->level);
     write_command_output(client->client_fd, level_str);
     free(level_str);
+    if (client->player->level == 8)
+        check_win(client, server);
 }
 
 void finish_incantation(server_t *server, client_t *client)
@@ -63,5 +87,5 @@ void finish_incantation(server_t *server, client_t *client)
     client->player->is_in_incantation = false;
     if (!can_start_incantation(server, client))
         return handle_incantation_failure(client);
-    handle_incantation_success(client, tile, old_level);
+    handle_incantation_success(client, tile, old_level, server);
 }

--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -57,11 +57,11 @@ static bool execute_if_free(server_t *server, client_t *user,
 {
     command_data_t data = get_command_data();
 
-    if (user->type != data.accepted_types[cmd_index])
-        return false;
     if (user->type == GRAPHICAL)
         return execute_graphical_command(server, user, buffer, cmd_index);
     if (user->type == AI && user->player->busy_until <= server->current_tick) {
+        if (cmd_index == 9)
+            write_command_output(user->client_fd, "Elevation underway\n");
         user->player->pending_cmd->args = strdup(buffer);
         user->player->pending_cmd->func = data.functions[cmd_index];
         if (data.times[cmd_index] > 0)
@@ -82,7 +82,8 @@ static bool find_and_execute(server_t *server, client_t *user, char *buffer)
     command_data_t data = get_command_data();
 
     for (int i = 0; data.commands[i] != NULL; i++) {
-        if (strncmp(buffer, data.commands[i], strlen(data.commands[i])) == 0)
+        if (strncmp(buffer, data.commands[i], strlen(data.commands[i])) == 0 &&
+            user->type == data.accepted_types[i])
             return execute_if_free(server, user, buffer, i);
     }
     return false;

--- a/src/Server/include/server.h
+++ b/src/Server/include/server.h
@@ -8,6 +8,7 @@
 #ifndef SERVER_H_
     #define SERVER_H_
     #include <sys/socket.h>
+    #include <stdbool.h>
     #include "client.h"
     #include "parsing.h"
     #include "tile.h"
@@ -25,6 +26,7 @@ typedef struct server_s {
     parsing_info_t *parsed_info;
     int *total_resources;
     int *current_resources;
+    int should_run;
 } server_t;
 
 void update_game_tick(server_t *server);
@@ -44,5 +46,6 @@ void add_to_command_queue(client_t *client, char *command);
 void free_node(client_t *node, server_t *server);
 void init_server_eggs(server_t *n_server);
 void free_all(server_t *server, parsing_info_t *parsed_info);
+int count_team(server_t *n_server);
 
 #endif /* !SERVER_H_ */

--- a/src/Server/main.c
+++ b/src/Server/main.c
@@ -80,7 +80,7 @@ static void disp_args(parsing_info_t *parsed_info)
 
 static void server_loop(server_t *server)
 {
-    while (should_continue_running()) {
+    while (should_continue_running() && server->should_run) {
         check_client(server);
     }
     printf("Server is shutting down\n");

--- a/src/Server/map/tick_update.c
+++ b/src/Server/map/tick_update.c
@@ -21,7 +21,7 @@ static bool tick_check(server_t *server, client_t *current)
     if (current != NULL && current->player != NULL)
         dead = check_player_starvation(server, current);
     if (dead == false && current != NULL &&
-        current->player != NULL)
+        current->player != NULL && current->player->is_in_incantation)
         finish_incantation(server, current);
     return dead;
 }

--- a/src/Server/network/connection.c
+++ b/src/Server/network/connection.c
@@ -182,6 +182,7 @@ static void init_server(server_t *server, parsing_info_t *parsed_info)
     server->parsed_info->client_nb = parsed_info->client_nb;
     server->parsed_info->frequence = parsed_info->frequence;
     server->eggs = NULL;
+    server->should_run = true;
     init_server_resources(server);
     copy_names(server, parsed_info);
 }

--- a/src/Server/network/connection_utils.c
+++ b/src/Server/network/connection_utils.c
@@ -16,7 +16,7 @@
 #include "../include/server.h"
 #include "../include/parsing.h"
 
-static int count_team(server_t *n_server)
+int count_team(server_t *n_server)
 {
     int i = 0;
 


### PR DESCRIPTION
This pull request introduces a mechanism to determine and announce the winning team in the game, alongside several supporting changes to ensure proper integration and functionality. The main updates include adding logic to check for a winning condition, modifying server behavior to halt upon victory, and ensuring commands are processed correctly for players engaged in incantation.

### Winning Condition and Server Termination:

* [`src/Server/command/finish_incantation.c`](diffhunk://#diff-1a1f4976fbb0745568ff8336fd30987e3cc7f9f0cb4e679b3b91f55561d4e3b6R39-R62): Added `handle_win` and `check_win` functions to detect when a team reaches the victory condition (six players at level 8) and terminate the server while announcing the winner. Updated `handle_incantation_success` to invoke `check_win` when a player reaches level 8. [[1]](diffhunk://#diff-1a1f4976fbb0745568ff8336fd30987e3cc7f9f0cb4e679b3b91f55561d4e3b6R39-R62) [[2]](diffhunk://#diff-1a1f4976fbb0745568ff8336fd30987e3cc7f9f0cb4e679b3b91f55561d4e3b6R74-R75)
* [`src/Server/include/server.h`](diffhunk://#diff-489c1271b110ad10582f361acf6dcd5f448820d0d06b25ed30422cd3a1759821R29): Introduced the `should_run` field in the `server_t` struct to control server termination upon victory.
* [`src/Server/main.c`](diffhunk://#diff-c802444d5cd5a412c4ddb5130393bd4a559069bd3d4a49bf2c40044abb28950fL83-R83): Modified the server loop to stop running when `should_run` is set to `false`.
* [`src/Server/network/connection.c`](diffhunk://#diff-0a09035b85cc4de7cd61eedf5acc3f38343c6094eadcd17fa8b61069f42e7500R185): Initialized `should_run` to `true` during server setup.

### Incantation Handling:

* [`src/Server/map/tick_update.c`](diffhunk://#diff-57c5ac984a772c9f02621dd8d42f5e6e250cad69f8314f3665409460abe42ff2L24-R24): Updated `tick_check` to ensure `finish_incantation` is called only for players actively involved in incantation.
* [`src/Server/command/finish_incantation.c`](diffhunk://#diff-1a1f4976fbb0745568ff8336fd30987e3cc7f9f0cb4e679b3b91f55561d4e3b6L66-R90): Adjusted `finish_incantation` to pass the `server` parameter to `handle_incantation_success` for proper integration with the winning condition logic.

### Command Execution:

* [`src/Server/command/parse_command.c`](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L60-R64): Added a message ("Elevation underway") for incantation commands and ensured commands are executed only for clients of the correct type. [[1]](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L60-R64) [[2]](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L85-R86)

### Codebase Enhancements:

* [`src/Server/include/server.h`](diffhunk://#diff-489c1271b110ad10582f361acf6dcd5f448820d0d06b25ed30422cd3a1759821R49): Made `count_team` function declaration available globally and added `stdbool.h` for boolean support. [[1]](diffhunk://#diff-489c1271b110ad10582f361acf6dcd5f448820d0d06b25ed30422cd3a1759821R49) [[2]](diffhunk://#diff-489c1271b110ad10582f361acf6dcd5f448820d0d06b25ed30422cd3a1759821R11)
* [`src/Server/network/connection_utils.c`](diffhunk://#diff-cc5b84466c50eee87b8950346a07bfaf51e2c51892bf895c0556e537b90cf26aL19-R19): Changed `count_team` function to non-static for broader accessibility.