### PR TITLE
[FEAT](Pbc command): Added pbc command and implemented in broadcast

### DIFF
--- a/src/Server/Makefile
+++ b/src/Server/Makefile
@@ -68,6 +68,7 @@ SRC = 	help.c								\
 		graphical_command/command_edi.c		\
 		graphical_command/command_pic.c		\
 		graphical_command/command_sst.c		\
+		graphical_command/command_pbc.c		\
 
 MAIN_OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(MAIN))
 MAIN_DEP = $(patsubst %.c, $(BUILD_DIR)/%.d, $(MAIN))

--- a/src/Server/command/broadcast.c
+++ b/src/Server/command/broadcast.c
@@ -5,6 +5,7 @@
 ** broadcast
 */
 #include "../include/command.h"
+#include "../include/graphical_commands.h"
 #include "../include/server.h"
 #include <string.h>
 #include <stdio.h>
@@ -116,13 +117,12 @@ void broadcast(server_t *server, client_t *user, char *buffer)
         return;
     }
     message = buffer + 10;
-    if (message[strlen(message) - 1] == '\n')
-        message[strlen(message) - 1] = '\0';
     current = server->client;
     if (current)
         current = current->next;
+    command_pbc(server, user, message);
     while (current) {
-        if (current->player && current != user)
+        if (current->player && current != user && current->type != GRAPHICAL)
             send_broadcast_to_client(server, user, current, message);
         current = current->next;
     }

--- a/src/Server/graphical_command/command_pbc.c
+++ b/src/Server/graphical_command/command_pbc.c
@@ -1,0 +1,35 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** command_pbc
+*/
+
+#include "../include/server.h"
+#include "../include/client.h"
+#include "../include/command.h"
+#include "../include/graphical_commands.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void command_pbc(server_t *server, client_t *client, char *buffer)
+{
+    graphical_client_t *graphical_client = NULL;
+    char *msg = NULL;
+    int size = 0;
+
+    if (!server || !client || !buffer ||
+        !server->graphical_clients || !client->player)
+        return;
+    size = snprintf(NULL, 0, "pbc #%d %s", client->client_id, buffer);
+    msg = malloc(size + 1);
+    if (!msg)
+        return;
+    snprintf(msg, size + 1, "pbc #%d %s", client->client_id, buffer);
+    graphical_client = server->graphical_clients;
+    while (graphical_client) {
+        write_command_output(graphical_client->client->client_fd, msg);
+        graphical_client = graphical_client->next;
+    }
+    free(msg);
+}

--- a/src/Server/include/graphical_commands.h
+++ b/src/Server/include/graphical_commands.h
@@ -18,6 +18,7 @@ void send_pin_command(server_t *server, client_t *client, client_t *recipient);
 void send_plv_command(server_t *server, client_t *client, client_t *recipient);
 void send_ebo_command(server_t *server, int egg_id);
 void command_pic(server_t *server, int x, int y, int level);
+void command_pbc(server_t *server, client_t *client, char *buffer);
 
 void send_tile_content_to_one_client(server_t *server, client_t *client);
 void send_team_names_to_one_client(server_t *server, client_t *client);


### PR DESCRIPTION
This pull request introduces a new graphical command, `command_pbc`, to handle broadcasting messages to graphical clients. The changes include adding the implementation of the new command, updating the `broadcast` function to integrate it, and modifying related files to support the new functionality.

### Addition of the `command_pbc` graphical command:

* **Implementation of `command_pbc`:** Added a new function `command_pbc` in `src/Server/graphical_command/command_pbc.c` to broadcast messages to graphical clients. This function constructs a formatted message, iterates through graphical clients, and sends the message to each client.

### Integration into existing functionality:

* **Update to `broadcast` function:** Modified the `broadcast` function in `src/Server/command/broadcast.c` to call `command_pbc` for broadcasting messages to graphical clients. Additionally, updated the logic to exclude graphical clients from receiving standard broadcast messages.

### Supporting changes:

* **Header file updates:** Added a declaration for `command_pbc` in the header file `src/Server/include/graphical_commands.h` to make the function accessible throughout the codebase.
* **Include dependency:** Added an include statement for `graphical_commands.h` in `src/Server/command/broadcast.c` to use the new `command_pbc` function.
* **Makefile update:** Updated `src/Server/Makefile` to include the new `command_pbc.c` file in the build process.