### PR TITLE
[FEAT](Seg command): Added Seg command and implemented it in finish_incantation

### DIFF
--- a/src/Server/Makefile
+++ b/src/Server/Makefile
@@ -70,6 +70,7 @@ SRC = 	help.c								\
 		graphical_command/command_sst.c		\
 		graphical_command/command_pbc.c		\
 		graphical_command/command_pgt.c		\
+		graphical_command/command_seg.c		\
 
 MAIN_OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(MAIN))
 MAIN_DEP = $(patsubst %.c, $(BUILD_DIR)/%.d, $(MAIN))

--- a/src/Server/command/finish_incantation.c
+++ b/src/Server/command/finish_incantation.c
@@ -41,6 +41,7 @@ static bool remove_resources(tile_t *tile, int level)
 static void handle_win(char *winner, server_t *server)
 {
     server->should_run = false;
+    command_seg(server, winner);
     printf("%s team are the winner of this Zappy tournament\n", winner);
 }
 

--- a/src/Server/graphical_command/command_seg.c
+++ b/src/Server/graphical_command/command_seg.c
@@ -1,0 +1,34 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** command_seg
+*/
+
+#include "../include/server.h"
+#include "../include/client.h"
+#include "../include/command.h"
+#include "../include/graphical_commands.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+void command_seg(server_t *server, const char *team_name)
+{
+    graphical_client_t *current = NULL;
+    char *buffer = NULL;
+    int size = 0;
+
+    if (!server || !server->graphical_clients || !team_name)
+        return;
+    size = snprintf(NULL, 0, "seg %s\n", team_name);
+    buffer = malloc(size + 1);
+    if (!buffer)
+        return;
+    snprintf(buffer, size + 1, "seg %s\n", team_name);
+    current = server->graphical_clients;
+    while (current) {
+        write_command_output(current->client->client_fd, buffer);
+        current = current->next;
+    }
+    free(buffer);
+}

--- a/src/Server/include/graphical_commands.h
+++ b/src/Server/include/graphical_commands.h
@@ -19,6 +19,8 @@ void send_plv_command(server_t *server, client_t *client, client_t *recipient);
 void send_ebo_command(server_t *server, int egg_id);
 void command_pic(server_t *server, int x, int y, int level);
 void command_pbc(server_t *server, client_t *client, char *buffer);
+void command_seg(server_t *server, const char *team_name);
+
 
 void send_tile_content_to_one_client(server_t *server, client_t *client);
 void send_team_names_to_one_client(server_t *server, client_t *client);


### PR DESCRIPTION
This pull request introduces a new graphical command, `command_seg`, which is used to notify graphical clients about the winning team in the Zappy tournament. The changes include the implementation of the command, its integration into the server's workflow, and updates to relevant files for proper functionality.

### Addition of `command_seg` graphical command:

* **Implementation of `command_seg`:** Added the `command_seg` function in `src/Server/graphical_command/command_seg.c`. This function sends a "seg" message to all graphical clients, indicating the winning team's name.
* **Declaration of `command_seg`:** Added the function prototype for `command_seg` in `src/Server/include/graphical_commands.h`. This ensures the function is accessible across the server codebase.

### Integration into server workflow:

* **Integration in `handle_win`:** Updated the `handle_win` function in `src/Server/command/finish_incantation.c` to call `command_seg` when the tournament ends, notifying graphical clients of the winner.

### Build system update:

* **Makefile update:** Added `graphical_command/command_seg.c` to the `SRC` variable in `src/Server/Makefile`, ensuring the new file is included in the build process.