### PR TITLE
[FEAT](Smg command): Added the smg command and added and example msg sent when resources are respawned

### DIFF
--- a/src/Server/Makefile
+++ b/src/Server/Makefile
@@ -72,6 +72,7 @@ SRC = 	help.c								\
 		graphical_command/command_pbc.c		\
 		graphical_command/command_pgt.c		\
 		graphical_command/command_seg.c		\
+		graphical_command/command_smg.c		\
 
 MAIN_OBJ = $(patsubst %.c, $(BUILD_DIR)/%.o, $(MAIN))
 MAIN_DEP = $(patsubst %.c, $(BUILD_DIR)/%.d, $(MAIN))

--- a/src/Server/graphical_command/command_smg.c
+++ b/src/Server/graphical_command/command_smg.c
@@ -1,0 +1,35 @@
+/*
+** EPITECH PROJECT, 2025
+** Zappy
+** File description:
+** command_smg
+*/
+
+#include "../include/server.h"
+#include "../include/client.h"
+#include "../include/command.h"
+#include "../include/graphical_commands.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void send_smg_command(server_t *server, const char *msg)
+{
+    graphical_client_t *current = NULL;
+    char *buffer = NULL;
+    int size = 0;
+
+    if (!server || !server->graphical_clients || !msg)
+        return;
+    size = snprintf(NULL, 0, "smg %s\n", msg);
+    buffer = malloc(size + 1);
+    if (!buffer)
+        return;
+    snprintf(buffer, size + 1, "smg %s\n", msg);
+    current = server->graphical_clients;
+    while (current) {
+        write_command_output(current->client->client_fd, buffer);
+        current = current->next;
+    }
+    free(buffer);
+}

--- a/src/Server/include/graphical_commands.h
+++ b/src/Server/include/graphical_commands.h
@@ -29,5 +29,6 @@ bool send_ppo_command(server_t *server, int id);
 void send_plv_to_all(server_t *server, client_t *client);
 void send_pin_to_all(server_t *server, client_t *client);
 void send_edi_command(server_t *server, int egg_id);
+void send_smg_command(server_t *server, const char *msg);
 
 #endif /* !GRAPHICAL_COMMANDS_H_ */

--- a/src/Server/map/resources_map.c
+++ b/src/Server/map/resources_map.c
@@ -8,6 +8,7 @@
 #include "../include/tile.h"
 #include "../include/server.h"
 #include "../include/command.h"
+#include "../include/graphical_commands.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -94,5 +95,6 @@ void respawn_resources(tile_t **map, server_t *server,
             current_resources[res] += missing;
         }
     }
+    send_smg_command(server, "Resources respawned");
     free(dist.tile_indices);
 }


### PR DESCRIPTION
This pull request introduces a new graphical command, `smg`, which broadcasts a server message to all graphical clients. The changes include adding the implementation of the `send_smg_command` function, updating the `Makefile` to include the new command file, and integrating the command into the resource respawn logic.

### Addition of the `smg` graphical command:
* **Implementation of `send_smg_command`:** Added a new function in `src/Server/graphical_command/command_smg.c` to send a server message (`smg`) to all connected graphical clients. This function constructs the message, iterates through the graphical clients, and writes the message to their respective file descriptors.
* **Header file update:** Declared the `send_smg_command` function in the `src/Server/include/graphical_commands.h` header file for use across the codebase.
* **Makefile update:** Included the new `command_smg.c` file in the `SRC` variable in `src/Server/Makefile` to ensure it is compiled as part of the project.

### Integration of the `smg` command:
* **Resource respawn logic:** Integrated the `send_smg_command` function into the `respawn_resources` function in `src/Server/map/resources_map.c` to broadcast a message ("Resources respawned") whenever resources are respawned on the map.
* **Include graphical commands header:** Added the `graphical_commands.h` header file to `src/Server/map/resources_map.c` to enable the use of the `send_smg_command` function.