### PR TITLE
[FEAT](Suc command): Added suc command and implemented it

### DIFF
--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -151,8 +151,11 @@ void execute_com(server_t *server, client_t *user, char *buffer)
         } else
             return send_info_new_client(server, user);
     }
-    if (!find_and_execute(server, user, buffer))
+    if (!find_and_execute(server, user, buffer)){
+        if (user->type == GRAPHICAL)
+            return write_command_output(user->client_fd, "suc\n");
         write_command_output(user->client_fd, "ko\n");
+    }
 }
 
 static void check_command(circular_buffer_t *temp_buffer, int cmd_length,


### PR DESCRIPTION
This pull request modifies the `execute_com` function in `src/Server/command/parse_command.c` to improve the handling of command execution results, particularly for graphical clients.

### Command execution handling improvements:

* [`src/Server/command/parse_command.c`](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L154-R159): Added a conditional check to send a "suc\n" response to graphical clients (`GRAPHICAL` type) when a command fails to execute, while retaining the "ko\n" response for other client types. This ensures graphical clients receive appropriate feedback.