### PR TITLE
[PR] Pull request for issue #196 : doc déploiement doc

### DIFF
--- a/.github/workflows/deployDoc.yml
+++ b/.github/workflows/deployDoc.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
 


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow to automate the deployment of a Docusaurus website to GitHub Pages. The workflow triggers on pushes to the `main` branch and includes steps for setting up the environment, building the website, and deploying it.

Deployment automation:

* [`.github/workflows/deployDoc.yml`](diffhunk://#diff-e4bfc7ab8666ff5fbaab9bb818fb2c6d20ebb579261c685245cf00279341d1c9R1-R34): Added a new workflow named "Deploy Docusaurus to GitHub Pages" that runs on `ubuntu-latest`. It checks out the repository, sets up Node.js (version 18), installs dependencies, builds the website, and deploys the generated files to GitHub Pages using the `peaceiris/actions-gh-pages` action.