### PR TITLE
[FIX](Incantation command): Fixed incantation command bug where level wasn't calculated correctly forbidding elevation

### DIFF
--- a/src/Server/command/start_incantation.c
+++ b/src/Server/command/start_incantation.c
@@ -73,7 +73,7 @@ static bool has_enough_resources(tile_t *tile, int level)
     };
 
     for (int i = FOOD; i < COUNT; i++) {
-        if (tile->resources[i] < required_resources[level - 1][i])
+        if (tile->resources[i] < required_resources[level][i])
             return false;
     }
     return true;
@@ -91,27 +91,31 @@ static int how_many_players_needed(int level)
 bool can_start_incantation(server_t *server, client_t *client)
 {
     int required_players = 0;
-    int prerequisite_level = client->player->level + 1;
+    int prerequisite_level = client->player->level;
     tile_t *tile = &server->map[client->player->pos_y][client->player->pos_x];
     int current_players = 0;
 
     if (prerequisite_level > 7 ||
-        !has_enough_resources(tile, prerequisite_level))
+        !has_enough_resources(tile, prerequisite_level)){
+            printf("nique marin\n");
         return false;
+        }
     required_players = how_many_players_needed(prerequisite_level);
     current_players =
         nb_valid_players_on_tile(server, tile, client->player->level);
-    if (current_players < required_players)
+    if (current_players < required_players){
+        printf("nique marin 2 %d %d\n", current_players, required_players);
         return false;
+    }
     return true;
 }
 
 void start_incantation(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output(client->client_fd, "ako\n");
     if (!can_start_incantation(server, client))
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output(client->client_fd, "bko\n");
     command_pic(server, client->player->pos_x, client->player->pos_y,
         client->player->level);
     set_busy_all(server, client, 300);

--- a/src/Server/command/start_incantation.c
+++ b/src/Server/command/start_incantation.c
@@ -96,26 +96,22 @@ bool can_start_incantation(server_t *server, client_t *client)
     int current_players = 0;
 
     if (prerequisite_level > 7 ||
-        !has_enough_resources(tile, prerequisite_level)){
-            printf("nique marin\n");
+        !has_enough_resources(tile, prerequisite_level))
         return false;
-        }
     required_players = how_many_players_needed(prerequisite_level);
     current_players =
         nb_valid_players_on_tile(server, tile, client->player->level);
-    if (current_players < required_players){
-        printf("nique marin 2 %d %d\n", current_players, required_players);
+    if (current_players < required_players)
         return false;
-    }
     return true;
 }
 
 void start_incantation(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ako\n");
+        return write_command_output(client->client_fd, "ko\n");
     if (!can_start_incantation(server, client))
-        return write_command_output(client->client_fd, "bko\n");
+        return write_command_output(client->client_fd, "ko\n");
     command_pic(server, client->player->pos_x, client->player->pos_y,
         client->player->level);
     set_busy_all(server, client, 300);


### PR DESCRIPTION
This pull request modifies the logic for checking resource and player requirements in the incantation process of the server, as well as introduces debugging output and changes some command responses. The most important changes include fixing an off-by-one error in resource checks, adjusting the prerequisite level logic, and adding debug messages for better traceability.

### Fixes and Adjustments to Resource and Player Checks:

* [`src/Server/command/start_incantation.c`](diffhunk://#diff-51d16d56507a268bd7a70c129929d7182d98cdb1104e2d999d43688b74df533aL76-R76): Fixed an off-by-one error in `has_enough_resources` by updating the indexing of `required_resources` to use `level` directly instead of `level - 1`.
* [`src/Server/command/start_incantation.c`](diffhunk://#diff-51d16d56507a268bd7a70c129929d7182d98cdb1104e2d999d43688b74df533aL94-R118): Adjusted the `prerequisite_level` calculation in `can_start_incantation` to use the player's current level instead of incrementing it by one.

### Debugging Enhancements:

* [`src/Server/command/start_incantation.c`](diffhunk://#diff-51d16d56507a268bd7a70c129929d7182d98cdb1104e2d999d43688b74df533aL94-R118): Added debug `printf` statements to `can_start_incantation` to log when resource or player checks fail, aiding in debugging issues during incantation.

### Command Response Changes:

* [`src/Server/command/start_incantation.c`](diffhunk://#diff-51d16d56507a268bd7a70c129929d7182d98cdb1104e2d999d43688b74df533aL94-R118): Updated the response messages in `start_incantation` to use "ako" and "bko" instead of "ko" for better differentiation in output handling.