### PR TITLE
[PR] pr for issue #204 fix segfault closing window

### DIFF
--- a/src/GUI/GameLoop.cpp
+++ b/src/GUI/GameLoop.cpp
@@ -86,7 +86,6 @@ int GameLoop::run() {
         m_graphics->EndDrawing();
         std::this_thread::sleep_for(std::chrono::milliseconds(16));
     }
-    m_graphics->CloseWindow();
     return 0;
 }
 

--- a/src/GUI/main.cpp
+++ b/src/GUI/main.cpp
@@ -33,7 +33,6 @@ int main(int argc, char** argv) {
             std::cerr << "[ERROR] Impossible de se connecter au serveur." << std::endl;
             return 84;
         }
-        std::thread networkThread(&NetworkManager::networkThreadLoop, &networkManager);
 
         auto gameLoop = std::make_shared<GameLoop>();
         gameLoop->setServerInfo(parser.getMachine(), parser.getPort());
@@ -42,7 +41,9 @@ int main(int argc, char** argv) {
             std::cerr << "Failed to initialize game components" << std::endl;
             return 84;
         }
-        return gameLoop->run();
+        gameLoop->run();
+        networkManager.disconnect();
+        return 0;
     } catch (const AException &e) {
         std::cerr << e.getFormattedMessage() << std::endl;
         return 84;


### PR DESCRIPTION
…o fix segfault closing window
This pull request includes changes to improve the cleanup and shutdown process in the `GameLoop` and `main` functions by ensuring proper disconnection from the network and removing unnecessary code.

### Improvements to cleanup and shutdown:

* [`src/GUI/GameLoop.cpp`](diffhunk://#diff-cb7c47164f436489a7a1228440372abcc6ebe09c516ca55f10905ec20969a446L89): Removed the call to `m_graphics->CloseWindow()` from the `GameLoop::run` method, as it is no longer necessary for the shutdown process.
* [`src/GUI/main.cpp`](diffhunk://#diff-17a7edba167008801dca945cd0d4df542fb6e02101c394d025a83d05323baa0cL45-R46): Replaced the direct return of `gameLoop->run()` with a call to `gameLoop->run()` followed by `networkManager.disconnect()`, ensuring proper disconnection from the network before exiting.

### Code simplification:

* [`src/GUI/main.cpp`](diffhunk://#diff-17a7edba167008801dca945cd0d4df542fb6e02101c394d025a83d05323baa0cL36): Removed the creation and management of a separate `networkThread`, simplifying the main function and the threading model.