### PR TITLE
[PR](Bug fixes): Fixed bug on gui for player and on server for connect_nbr

### DIFF
--- a/src/GUI/gameController/GameState.cpp
+++ b/src/GUI/gameController/GameState.cpp
@@ -181,10 +181,22 @@ void GameState::addOrUpdatePlayer(const PlayerInfoData& playerData) {
 
     if (_players.find(playerId) != _players.end()) {
         const auto& oldPlayer = _players[playerId];
-        removePlayerFromTile(playerId, oldPlayer.getX(), oldPlayer.getY());
+        PlayerInfoData updatedPlayer = playerData;
+        if (updatedPlayer.getTeamName().empty() && !oldPlayer.getTeamName().empty())
+            updatedPlayer.setTeamName(oldPlayer.getTeamName());
+        if (updatedPlayer.getLevel() == 0 && oldPlayer.getLevel() > 0)
+            updatedPlayer.setLevel(oldPlayer.getLevel());
+        if (oldPlayer.getX() != updatedPlayer.getX() || oldPlayer.getY() != updatedPlayer.getY()) {
+            removePlayerFromTile(playerId, oldPlayer.getX(), oldPlayer.getY());
+            _players[playerId] = updatedPlayer;
+            addPlayerToTile(playerId, updatedPlayer.getX(), updatedPlayer.getY());
+        } else {
+            _players[playerId] = updatedPlayer;
+        }
+    } else {
+        _players[playerId] = playerData;
+        addPlayerToTile(playerId, playerData.getX(), playerData.getY());
     }
-    _players[playerId] = playerData;
-    addPlayerToTile(playerId, playerData.getX(), playerData.getY());
 }
 
 void GameState::removePlayer(int playerId) {

--- a/src/GUI/renderer/strategies/DetailedTileRenderStrategy.cpp
+++ b/src/GUI/renderer/strategies/DetailedTileRenderStrategy.cpp
@@ -50,8 +50,9 @@ void DetailedTileRenderStrategy::renderTile(const std::shared_ptr<IGraphicsLib>&
             renderResourceIndicator(graphicsLib, position, static_cast<ResourceType>(i), quantity, tileSize);
         }
     }
-    for (int playerId : tileData.playerIds) {
-        renderPlayerIndicator(graphicsLib, position, playerId, tileSize);
+    for (int i = 0; i < static_cast<int>(tileData.playerIds.size()); ++i) {
+        int playerId = tileData.playerIds[i];
+        renderPlayerIndicator(graphicsLib, position, playerId, tileSize, i, tileData.playerIds.size());
     }
     for (int eggId : tileData.eggIds) {
         renderEggIndicator(graphicsLib, position, eggId, tileSize);
@@ -115,17 +116,28 @@ void DetailedTileRenderStrategy::renderResourceIndicator(const std::shared_ptr<I
 }
 
 void DetailedTileRenderStrategy::renderPlayerIndicator(const std::shared_ptr<IGraphicsLib>& graphicsLib,
-    ZappyTypes::Vector3 position,
-    int playerId,
-    float tileSize) {
+    ZappyTypes::Vector3 position, int playerId, float tileSize, int playerIndex, int totalPlayers) {
     auto playerInfo = gameState->getPlayerInfo(playerId);
-    if (!playerInfo) return;
+    if (!playerInfo) {
+        std::cout << "WARNING: Player " << playerId << " not found in gameState during rendering!" << std::endl;
+        return;
+    }
+    int orientation = playerInfo->getOrientation();
+    std::string teamName = playerInfo->getTeamName();
+    if (orientation < 1 || orientation > 4)
+        orientation = 1;
+    ZappyTypes::Vector3 playerPos = position;
+    if (totalPlayers > 1) {
+        float offsetRadius = tileSize * 0.3f;
+        float angle = (2.0f * M_PI * playerIndex) / totalPlayers;
+        playerPos.x += offsetRadius * std::cos(angle);
+        playerPos.z += offsetRadius * std::sin(angle);
+    }
     ZappyTypes::Color playerColor = {255, 0, 0, 255};
     ZappyTypes::Color borderColor = {80, 80, 80, 255};
     ZappyTypes::Color directionColor = {255, 255, 0, 255};
     float playerSize = tileSize * 0.25f;
     float playerHeight = tileSize * 0.5f;
-    ZappyTypes::Vector3 playerPos = position;
     playerPos.y = position.y + 0.4f;
     graphicsLib->DrawCylinder(playerPos, playerSize, playerSize, playerHeight, 8, playerColor);
     float halfSize = playerSize;
@@ -167,83 +179,70 @@ void DetailedTileRenderStrategy::renderPlayerIndicator(const std::shared_ptr<IGr
     graphicsLib->DrawLine3D({playerPos.x - halfSize, bottomY, playerPos.z + halfSize},
                            {playerPos.x - halfSize, topY, playerPos.z + halfSize},
                            borderColor);
-    if (playerInfo) {
-        float arrowSize = playerSize * 1.5f;
-        float arrowHeight = topY + 0.5f;
-        ZappyTypes::Vector3 arrowStart = playerPos;
-        arrowStart.y = arrowHeight;
-        ZappyTypes::Vector3 arrowEnd = arrowStart;
-        int orientation = playerInfo->getOrientation();
-        switch (orientation) {
-            case 1: // North
-                arrowEnd.z -= arrowSize;
-                break;
-            case 2: // East
-                arrowEnd.x += arrowSize;
-                break;
-            case 3: // South
-                arrowEnd.z += arrowSize;
-                break;
-            case 4: // West
-                arrowEnd.x -= arrowSize;
-                break;
-            default:
-                break;
-        }
-        graphicsLib->DrawLine3D(arrowStart, arrowEnd, directionColor);
-        float arrowHeadSize = arrowSize * 0.3f;
-        ZappyTypes::Vector3 arrowHeadLeft = arrowEnd;
-        ZappyTypes::Vector3 arrowHeadRight = arrowEnd;
 
-        switch (orientation) {
-            case 1: // North
-                arrowHeadLeft.x -= arrowHeadSize * 0.5f;
-                arrowHeadLeft.z += arrowHeadSize;
-                arrowHeadRight.x += arrowHeadSize * 0.5f;
-                arrowHeadRight.z += arrowHeadSize;
-                break;
-            case 2: // East
-                arrowHeadLeft.x -= arrowHeadSize;
-                arrowHeadLeft.z -= arrowHeadSize * 0.5f;
-                arrowHeadRight.x -= arrowHeadSize;
-                arrowHeadRight.z += arrowHeadSize * 0.5f;
-                break;
-            case 3: // South
-                arrowHeadLeft.x -= arrowHeadSize * 0.5f;
-                arrowHeadLeft.z -= arrowHeadSize;
-                arrowHeadRight.x += arrowHeadSize * 0.5f;
-                arrowHeadRight.z -= arrowHeadSize;
-                break;
-            case 4: // West
-                arrowHeadLeft.x += arrowHeadSize;
-                arrowHeadLeft.z -= arrowHeadSize * 0.5f;
-                arrowHeadRight.x += arrowHeadSize;
-                arrowHeadRight.z += arrowHeadSize * 0.5f;
-                break;
-            default:
-                break;
-        }
-        graphicsLib->DrawLine3D(arrowEnd, arrowHeadLeft, directionColor);
-        graphicsLib->DrawLine3D(arrowEnd, arrowHeadRight, directionColor);
-        if (!playerInfo->getTeamName().empty()) {
-            ZappyTypes::Vector3 textPosition = playerPos;
-            textPosition.y = position.y + playerHeight + 1.0f;
-            std::string teamName = playerInfo->getTeamName();
-            if (teamName.length() > 10) {
-                teamName = teamName.substr(0, 8) + "...";
-            }
-            ZappyTypes::Color textColor = {255, 255, 255, 255};
-            unsigned int hash = 0;
-            for (char c : playerInfo->getTeamName()) {
-                hash = hash * 31 + c;
-            }
-            textColor.r = 128 + (hash % 128);
-            textColor.g = 128 + ((hash / 256) % 128);
-            textColor.b = 128 + ((hash / 65536) % 128);
-            float textSize = 0.1f * playerSize;
-            renderText3D(graphicsLib, teamName, textPosition, textSize, textColor);
-        }
+    float arrowSize = playerSize * 1.5f;
+    float arrowHeight = topY + 0.5f;
+    ZappyTypes::Vector3 arrowStart = playerPos;
+    arrowStart.y = arrowHeight;
+    ZappyTypes::Vector3 arrowEnd = arrowStart;
+    switch (orientation) {
+        case 1: // North
+            arrowEnd.z += arrowSize;
+            break;
+        case 4: // WEST
+            arrowEnd.x += arrowSize;
+            break;
+        case 3: // South
+            arrowEnd.z -= arrowSize;
+            break;
+        case 2: // EAST
+            arrowEnd.x -= arrowSize;
+            break;
     }
+    graphicsLib->DrawLine3D(arrowStart, arrowEnd, directionColor);
+    float arrowHeadSize = arrowSize * 0.3f;
+    ZappyTypes::Vector3 arrowHeadLeft = arrowEnd;
+    ZappyTypes::Vector3 arrowHeadRight = arrowEnd;
+
+    switch (orientation) {
+        case 1: // North
+            arrowHeadLeft.x -= arrowHeadSize * 0.5f;
+            arrowHeadLeft.z -= arrowHeadSize;
+            arrowHeadRight.x += arrowHeadSize * 0.5f;
+            arrowHeadRight.z -= arrowHeadSize;
+            break;
+        case 4: // WEST
+            arrowHeadLeft.x -= arrowHeadSize;
+            arrowHeadLeft.z -= arrowHeadSize * 0.5f;
+            arrowHeadRight.x -= arrowHeadSize;
+            arrowHeadRight.z += arrowHeadSize * 0.5f;
+            break;
+        case 3: // South
+            arrowHeadLeft.x -= arrowHeadSize * 0.5f;
+            arrowHeadLeft.z += arrowHeadSize;
+            arrowHeadRight.x += arrowHeadSize * 0.5f;
+            arrowHeadRight.z += arrowHeadSize;
+            break;
+        case 2: // EAST
+            arrowHeadLeft.x += arrowHeadSize;
+            arrowHeadLeft.z -= arrowHeadSize * 0.5f;
+            arrowHeadRight.x += arrowHeadSize;
+            arrowHeadRight.z += arrowHeadSize * 0.5f;
+            break;
+    }
+    graphicsLib->DrawLine3D(arrowEnd, arrowHeadLeft, directionColor);
+    graphicsLib->DrawLine3D(arrowEnd, arrowHeadRight, directionColor);
+    ZappyTypes::Vector3 textPosition = playerPos;
+    textPosition.y = position.y + playerHeight + 0.5f + (playerIndex * 0.3f);
+    std::string displayText = teamName.empty() ? ("P" + std::to_string(playerId)) : teamName;
+    if (displayText.length() > 10)
+        displayText = displayText.substr(0, 8) + "...";
+    float textSize = 0.4f;
+    float textWidth = displayText.length() * textSize * 0.6f;
+    textPosition.x -= textWidth / 2.0f;
+    textPosition.y += 0.1f;
+    ZappyTypes::Color textColor = ZappyTypes::Color{0, 0, 0, 255};
+    renderText3D(graphicsLib, displayText, textPosition, textSize, textColor);
 }
 
 void DetailedTileRenderStrategy::renderText3D(const std::shared_ptr<IGraphicsLib>& graphicsLib,
@@ -251,10 +250,9 @@ void DetailedTileRenderStrategy::renderText3D(const std::shared_ptr<IGraphicsLib
     ZappyTypes::Vector3 position,
     float fontSize,
     ZappyTypes::Color color) {
-    if (text.empty()) {
+    if (text.empty() || fontSize <= 0.05f)
         return;
-    }
-    float fontSpacing = 0.05f;
+    float fontSpacing = 0.1f;
     float lineSpacing = -0.1f;
     bool backface = true;
     graphicsLib->DrawText3D(text, position, fontSize, fontSpacing, lineSpacing, backface, color);

--- a/src/GUI/renderer/strategies/DetailedTileRenderStrategy.hpp
+++ b/src/GUI/renderer/strategies/DetailedTileRenderStrategy.hpp
@@ -29,7 +29,9 @@ private:
     void renderPlayerIndicator(const std::shared_ptr<IGraphicsLib>& graphicsLib,
         ZappyTypes::Vector3 position,
         int playerId,
-        float tileSize);
+        float tileSize,
+        int playerIndex = 0,
+        int totalPlayers = 1);
     void renderEggIndicator(const std::shared_ptr<IGraphicsLib>& graphicsLib,
         ZappyTypes::Vector3 position,
         int eggId,

--- a/src/Server/command/connect_nbr.c
+++ b/src/Server/command/connect_nbr.c
@@ -25,20 +25,6 @@ static int count_team_eggs(server_t *server, char *team_name)
     return count;
 }
 
-static int count_team_players(server_t *server, char *team_name)
-{
-    client_t *current = server->client;
-    int count = 0;
-
-    while (current) {
-        if (current->player && current->player->team_name &&
-            strcmp(current->player->team_name, team_name) == 0)
-            count++;
-        current = current->next;
-    }
-    return count;
-}
-
 static void format_response(int available_slots, client_t *client)
 {
     size_t res_size = snprintf(NULL, 0, "%d\n", available_slots) + 1;
@@ -52,9 +38,7 @@ static void format_response(int available_slots, client_t *client)
 int connect_nbr_srv(server_t *server, char *team)
 {
     int team_eggs = count_team_eggs(server, team);
-    int team_players = count_team_players(server, team);
-    int max_clients = server->parsed_info->client_nb;
-    int available_slots = max_clients - (team_players + team_eggs);
+    int available_slots = team_eggs;
 
     if (available_slots < 0)
         available_slots = 0;

--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -126,7 +126,7 @@ void execute_com(server_t *server, client_t *user, char *buffer)
             return send_info_new_client(server, user);
     }
     if (!find_and_execute(server, user, buffer)){
-        if (user->type == GRAPHICAL)
+        if (user->is_fully_connected && user->type == GRAPHICAL)
             return write_command_output(user->client_fd, "suc\n");
         write_command_output(user->client_fd, "ko\n");
     }

--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -128,7 +128,8 @@ void execute_com(server_t *server, client_t *user, char *buffer)
     if (!find_and_execute(server, user, buffer)){
         if (user->is_fully_connected && user->type == GRAPHICAL)
             return write_command_output(user->client_fd, "suc\n");
-        write_command_output(user->client_fd, "ko\n");
+        if (user->is_fully_connected)
+            write_command_output(user->client_fd, "ko\n");
     }
 }
 


### PR DESCRIPTION
This pull request introduces several updates to the game logic, rendering system, and server code to improve functionality and maintainability. The most significant changes include enhancements to player state management, improvements to the rendering of player indicators, and simplifications in server-side logic for team-related operations.

### Game Logic Improvements:
* Updated `GameState::addOrUpdatePlayer` to preserve existing player attributes (e.g., team name and level) when updating player data, ensuring continuity in state.

### Rendering Enhancements:
* Refactored `DetailedTileRenderStrategy::renderPlayerIndicator` to support rendering multiple players on the same tile with positional offsets, display player orientation, and dynamically adjust text labels for better clarity. Added warnings for missing player data during rendering. [[1]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL53-R55) [[2]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL118-L128) [[3]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL170-L191) [[4]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL201-R255)
* Adjusted player arrow orientation logic to fix inconsistencies in direction rendering. [[1]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL170-L191) [[2]](diffhunk://#diff-28fa7930ce2244c37dbbc6fc74c613f5689bfa29dd9dfaef7cb0c802940dd2dcL201-R255)
* Updated the `renderPlayerIndicator` method signature in `DetailedTileRenderStrategy.hpp` to include player index and total players for better rendering coordination.

### Server Logic Simplifications:
* Removed the `count_team_players` function and simplified the logic in `connect_nbr_srv` to calculate available slots using only team eggs, reducing redundancy. [[1]](diffhunk://#diff-97de128cad7eb6faa567453bdea94b62e037ead66ae4d3271334126f69d36c03L28-L41) [[2]](diffhunk://#diff-97de128cad7eb6faa567453bdea94b62e037ead66ae4d3271334126f69d36c03L55-R41)
* Added a check in `execute_com` to ensure commands are only processed for fully connected graphical clients, improving command validation.