### PR TITLE
[PR] pull request for issue #211 bug mort player affichage graphique

### DIFF
--- a/src/GUI/gameController/GameController.cpp
+++ b/src/GUI/gameController/GameController.cpp
@@ -101,6 +101,10 @@ void GameController::handlePlayerInfo(std::shared_ptr<IMessageData> data) {
     auto existingPlayer = _gameState->getPlayerInfo(playerId);
 
     if (existingPlayer) {
+        if (!playerData->isAlive()) {
+            _gameState->removePlayer(playerId);
+            return;
+        }
         int oldX = existingPlayer->getX();
         int oldY = existingPlayer->getY();
         int newX = playerData->getX();
@@ -135,13 +139,6 @@ void GameController::handleResourceDrop(std::shared_ptr<IMessageData> data) {
 
 void GameController::handleResourceCollect(std::shared_ptr<IMessageData> data) {
     auto resourceData = std::static_pointer_cast<ResourceData>(data);
-}
-
-void GameController::handlePlayerDeath(std::shared_ptr<IMessageData> data) {
-    auto playerData = std::static_pointer_cast<PlayerInfoData>(data);
-    int playerId = playerData->getId();
-
-    _gameState->removePlayer(playerId);
 }
 
 void GameController::handleIncantationStart(std::shared_ptr<IMessageData> data) {

--- a/src/GUI/gameController/GameController.hpp
+++ b/src/GUI/gameController/GameController.hpp
@@ -51,7 +51,6 @@ private:
     void handlePlayerBroadcast(std::shared_ptr<IMessageData> data);
     void handleResourceDrop(std::shared_ptr<IMessageData> data);
     void handleResourceCollect(std::shared_ptr<IMessageData> data);
-    void handlePlayerDeath(std::shared_ptr<IMessageData> data);
     void handleIncantationStart(std::shared_ptr<IMessageData> data);
     void handleIncantationEnd(std::shared_ptr<IMessageData> data);
     void handleEggLaying(std::shared_ptr<IMessageData> data);

--- a/src/GUI/network/protocol/ProtocolParser.cpp
+++ b/src/GUI/network/protocol/ProtocolParser.cpp
@@ -263,6 +263,7 @@ Message ProtocolParser::parsePlayerDeath(const std::string &message) {
     int id = parseIntParameter(params[0]);
 
     auto playerInfoData = std::make_shared<PlayerInfoData>(id, 0, 0, 0, 0);
+    playerInfoData->setIsAlive(false);
     return Message(PDI_HEADER, extractCommandParameter(message), playerInfoData);
 }
 

--- a/src/GUI/network/protocol/messageData/PlayerInfoData.hpp
+++ b/src/GUI/network/protocol/messageData/PlayerInfoData.hpp
@@ -13,9 +13,9 @@
 
 class PlayerInfoData : public IMessageData {
     public:
-        PlayerInfoData() : _id(0), _x(0), _y(0), _orientation(0), _level(0), _teamName("") {}
+        PlayerInfoData() : _id(0), _x(0), _y(0), _orientation(0), _level(0), _teamName(""), _isAlive(true) {}
         PlayerInfoData(int id, int x, int y, int orientation, int level, const std::string& teamName = "")
-            : _id(id), _x(x), _y(y), _orientation(orientation), _level(level), _teamName(teamName) {}
+            : _id(id), _x(x), _y(y), _orientation(orientation), _level(level), _teamName(teamName), _isAlive(true) {}
         MessageType getType() const override { return MessageType::PlayerInfo; }
 
         int getId() const { return _id; }
@@ -31,6 +31,8 @@ class PlayerInfoData : public IMessageData {
         void setOrientation(int value) { _orientation = value; }
         void setLevel(int value) { _level = value; }
         void setTeamName(const std::string& value) { _teamName = value; }
+        void setIsAlive(bool value) { _isAlive = value; }
+        bool isAlive() const { return _isAlive; }
 
     private:
         int _id;
@@ -39,6 +41,7 @@ class PlayerInfoData : public IMessageData {
         int _orientation;
         int _level;
         std::string _teamName;
+        bool _isAlive;
 };
 
 #endif /* !PLAYER_INFO_DATA_HPP_ */


### PR DESCRIPTION
This pull request refactors the handling of player deaths in the game logic by removing the `handlePlayerDeath` method and integrating its functionality into the existing `handlePlayerInfo` method. Additionally, it introduces a new `isAlive` property to the `PlayerInfoData` class, which simplifies the management of player state. Below are the key changes grouped by theme:

### Game Logic Refactoring:

* Removed the `handlePlayerDeath` method from both the `GameController` class implementation in `GameController.cpp` and its declaration in `GameController.hpp`. The logic for handling player removal due to death is now incorporated into the `handlePlayerInfo` method. [[1]](diffhunk://#diff-e95f9e5f3e05a945df6d9e5197dce6c759a035fb978922801eacef0633c7ee40L140-L146) [[2]](diffhunk://#diff-457b8ce8ad042733ed092e341d0323235fec37ba9c74bef75899db869354fd7fL54)
* Updated the `handlePlayerInfo` method to check the new `isAlive` property of `PlayerInfoData`. If a player is not alive, the player is removed from the game state, and the method exits early.

### Player State Management:

* Added a new `isAlive` boolean property to the `PlayerInfoData` class, initialized to `true` by default. This property tracks whether a player is alive. [[1]](diffhunk://#diff-44a3532087dbced05d79da76cf043de5b870d1a05c6f5f85dae00137f8ecacb8L16-R18) [[2]](diffhunk://#diff-44a3532087dbced05d79da76cf043de5b870d1a05c6f5f85dae00137f8ecacb8R44)
* Added `setIsAlive` and `isAlive` methods to the `PlayerInfoData` class to allow setting and retrieving the `isAlive` property.

### Protocol Handling:

* Updated the `ProtocolParser::parsePlayerDeath` method to set the `isAlive` property of `PlayerInfoData` to `false` when a player death message is parsed.