### PR TITLE
[PR] Ai 0 to 8 strategy

### DIFF
--- a/src/AI/agent/agent.py
+++ b/src/AI/agent/agent.py
@@ -3,11 +3,12 @@ from agent.socketManager import SocketManager
 from agent.decisionManager import DecisionManager
 from agent.broadcastManager import BroadcastManager
 from logger.logger import Logger
-from constants.upgrades import get_total_upgrade_resources
+from constants.upgrades import get_total_upgrade_resources, minimum_players_for_upgrade
 import utils.encryption as encryption
 import utils.zappy as zappy
 import socket
 import sys
+
 
 class Agent:
   def __init__(self, ip, port, team, agent_id=0, performance_mode=False):
@@ -21,6 +22,7 @@ class Agent:
       self.map_size_x = None
       self.map_size_y = None
       self.current_behaviour = "BigDyson"
+      self.tick = 0
       encryption.secret_key = encryption.secret_key + self.team
 
       self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -65,28 +67,23 @@ class Agent:
     team_slots = self.send_command(self.team)
     map_size = self.get_message(timeout=4)
 
-    if map_size is None:
-      print("Failed to retrieve map size from server.")
+    if welcome_msg is None or team_slots is None or map_size is None \
+    or welcome_msg == "ko" or team_slots == "ko" or map_size == "ko":
+      print("Failed to retrieve necessary information from server.")
       sys.exit(1)
+
+    self.id = int(team_slots)
     self.map_size_x = int(map_size.split()[0])
     self.map_size_y = int(map_size.split()[1])
 
-    if welcome_msg == "WELCOME":
-      print(f"Welcome message {welcome_msg}")
-    else:
-      print(f"Unexpected welcome message: {welcome_msg}")
-      sys.exit(1)
-
-    if (team_slots == "ko"):
-        print("Failed to join team. Either the team is full, or its name is incorrect.")
-        sys.exit(1)
-    else:
-      print(f"Joined team {self.team} successfully, {team_slots} slots left in the team.")
-
+    print(f"Welcome message {welcome_msg}")
+    print(f"Joined team {self.team} successfully, {team_slots} slots left in the team.")
     print(f"Map size: {map_size}")
+
     self.running = True
     self._run()
-    self._stop()
+    self.stop()
+
 
   def stop(self):
     if self.running:
@@ -102,10 +99,14 @@ class Agent:
       try:
         self.broadcastManager.send_broadcast("I", f"{self.last_known_inventory}")  #? Envoyer ses infos aux autres
         self._process_server_message()
-        self._update_self_state()           # TODO(ms-tristan): update l'état de l'agent actuel en fonction des informations reçues
-        self.decisionManager.take_action()  # TODO(ms-tristan): recréer l'arbre de décision pour prendre en compte les nouvelles actions
+        self.decisionManager.take_action()
+        # on laisse l'update en dessous de la prise de décision
+        # pour que les agents ne rebougent pas après avoir reçu un broadcast sur la même case
+        self._update_self_state()
         sleep(0.1)
-
+        self.tick += 1
+        if self.tick > 10:
+          self.tick = 0
       except BrokenPipeError:
         print(f"Agent {self.id}: Connection closed by server.")
       except Exception as e:
@@ -131,15 +132,23 @@ class Agent:
 
 
   def _update_self_state(self):
-
     #? On détermine le rôle de l'agent en fonction de son id
     agent_ids = list(self.other_agents.keys())
     agent_ids.append(self.id)
     agent_ids.sort()
-    if agent_ids.index(self.id) < 8:
+    if agent_ids.index(self.id) <= minimum_players_for_upgrade:
       self.current_role = "miner"
     else:
       self.current_role = "fighter"
+
+    agents_to_remove = []
+    for agent_id, items in self.other_agents.items():
+      if items['last_ping'] > self.tick:
+        agents_to_remove.append(agent_id)
+
+    for agent_id in agents_to_remove:
+      print(f"Removing agent {agent_id} from other_agents due to inactivity.")
+      del self.other_agents[agent_id]
 
     #? On check si l'inventaire de tout le monde permet d'upgrade de 0 à 8
     if self.current_phase == "collecting":
@@ -168,10 +177,13 @@ class Agent:
         print("Not all required resources for upgrade are available.")
 
     elif self.current_phase == "rallying":
-      distance_to_player, amount_of_players = zappy.get_closest_of_item(self.last_known_surroundings, "player")
-      if amount_of_players >= 6:
-        print("Enough players gathered for upgrade.")
-        self.current_phase = "setting"
+      for agent_info in self.other_agents.items():
+        if agent_info[1]['direction'] is None or agent_info[1]['direction'] != 0:
+          print(f"Agent {agent_info[0]} direction: {agent_info[1]['direction']}")
+          print("Waiting for all agents to be ready for setting.")
+          return
+      print("All agents are ready for setting.")
+      self.current_phase = "setting"
 
     elif self.current_phase == "setting":
       last_surroundings = self.last_known_surroundings
@@ -200,9 +212,17 @@ class Agent:
     return self.socketManager.has_messages()
 
   def update_agent_info(self, agent_id, direction, inventory):
+    if direction is None or inventory is None:
+      if agent_id is None:
+        return
+      if agent_id in self.other_agents:
+        del self.other_agents[agent_id]
+      return
+
     self.other_agents[agent_id] = {
         "direction": direction,
-        "inventory": inventory
+        "inventory": inventory,
+        "last_ping": self.tick
     }
 
   def update_last_known_enemy_direction(self, direction):

--- a/src/AI/agent/behaviors.py
+++ b/src/AI/agent/behaviors.py
@@ -91,6 +91,17 @@ class BigDysonBehavior(Behavior):
     self.agent.send_command("Forward")
     self.agent.send_command("Left")
 
+
+class FoodBigDysonBehavior(Behavior):
+  def execute(self, surroundings=None, inventory=None):
+    for _ in range(self.agent.map_size_x):
+      self.agent.send_command("Forward")
+      AgentActionManager(self.agent).take_all_of_item_here("food")
+    self.agent.send_command("Right")
+    self.agent.send_command("Forward")
+    self.agent.send_command("Left")
+
+
 class GetFoodAndMineralsBehavior(Behavior):
   def execute(self, surroundings=None, inventory=None):
     if not surroundings or not inventory:
@@ -138,6 +149,11 @@ class TakeAllFoodHereBehavior(Behavior):
     AgentActionManager(self.agent).take_all_of_item_here("food")
 
 
+class TakeOneFoodHereBehavior(Behavior):
+  def execute(self, surroundings=None, inventory=None):
+    self.agent.send_command("Take food")
+
+
 class DropEveryMineralsBehavior(Behavior):
   def execute(self, surroundings=None, inventory=None):
     if not inventory:
@@ -151,3 +167,16 @@ class DropEveryMineralsBehavior(Behavior):
       amount = inventory_dict[mineral]
       for _ in range(amount):
         self.agent.send_command(f"Set {mineral}")
+
+
+class DropAllFoodBehavior(Behavior):
+  def execute(self, surroundings=None, inventory=None):
+    if not inventory:
+      print("DropAllFoodBehavior: Inventory is None.")
+      return
+
+    inventory_dict = zappy.inventory_to_dict(inventory)
+    if "food" in inventory_dict:
+      amount = inventory_dict["food"]
+      for _ in range(amount):
+        self.agent.send_command("Set food")

--- a/src/AI/agent/decisionManager.py
+++ b/src/AI/agent/decisionManager.py
@@ -1,7 +1,4 @@
-import utils.encryption as encryption
 import agent.behaviors as behaviors
-import utils.zappy as zappy
-from random import choices
 
 class DecisionManager:
   def __init__(self, agent):
@@ -13,11 +10,14 @@ class DecisionManager:
       "Upgrade": behaviors.UpgradeBehavior(agent),
       "Dyson": behaviors.DysonBehavior(agent),
       "BigDyson": behaviors.BigDysonBehavior(agent),
-      "JoinTeamMates": behaviors.JoinTeamMatesBehavior(agent),
+      "FoodBigDyson": behaviors.FoodBigDysonBehavior(agent),
       "FoodDyson": behaviors.FoodDysonBehavior(agent),
+      "JoinTeamMates": behaviors.JoinTeamMatesBehavior(agent),
       "TakeEverythingHere": behaviors.TakeEverythingHereBehavior(agent),
       "TakeAllFoodHere": behaviors.TakeAllFoodHereBehavior(agent),
+      "TakeOneFoodHere": behaviors.TakeOneFoodHereBehavior(agent),
       "DropEveryMinerals": behaviors.DropEveryMineralsBehavior(agent),
+      "DropAllFood": behaviors.DropAllFoodBehavior(agent),
       "None": behaviors.NoActionBehavior(agent),
       "": behaviors.NoActionBehavior(agent),
     }
@@ -25,9 +25,9 @@ class DecisionManager:
 
     self.decisions = {
       "collecting": {"miner": ["BigDyson"], "fighter": ["FoodDyson"]},
-      "rallying": {"miner": ["JoinTeamMates", "TakeAllFoodHere"], "fighter": ["FoodDyson"]},
-      "setting": {"miner": ["DropEveryMinerals"], "fighter": ["FoodDyson"]},
-      "upgrading": {"miner": ["Upgrade"], "fighter": ["FoodDyson"]}
+      "rallying": {"miner": ["JoinTeamMates", "TakeAllFoodHere"], "fighter": ["JoinTeamMates"]},
+      "setting": {"miner": ["DropEveryMinerals"], "fighter": ["DropAllFood"]},
+      "upgrading": {"miner": ["Upgrade", "TakeOneFoodHere", "TakeOneFoodHere"], "fighter": ["FoodBigDyson"]}
     }
 
 
@@ -44,5 +44,4 @@ class DecisionManager:
 
     for action in self.decisions[self.agent.current_phase][self.agent.current_role]:
       self.behaviors[action].execute(surroundings, inventory)
-      print(f"Executed action: {action}")
     # print(inventory)

--- a/src/AI/constants/upgrades.py
+++ b/src/AI/constants/upgrades.py
@@ -1,3 +1,6 @@
+
+minimum_players_for_upgrade = 6
+
 upgrades = {
     1 : {
         "name": "lvl 1 -> 2",


### PR DESCRIPTION
This pull request introduces significant updates to the agent's behavior management system, including the addition of a new phase (`setting`), enhancements to decision-making logic, and the implementation of a new behavior for resource management. These changes aim to streamline agent actions across different phases and improve resource handling during upgrades.

### Updates to Agent Phases and State Management:

* **Addition of the `setting` phase**: Introduced a new phase (`setting`) in the agent's lifecycle to handle pre-upgrade resource validation. The `_update_self_state` method now transitions to this phase after sufficient players have gathered, and checks for required resources before proceeding to the `upgrading` phase. (`src/AI/agent/agent.py`, [[1]](diffhunk://#diff-301efb874341e0efef71a020c186df7a33b71778a55ccd8d791f5adacb71a322L44-R44) [[2]](diffhunk://#diff-301efb874341e0efef71a020c186df7a33b71778a55ccd8d791f5adacb71a322L172-R187)

### Enhancements to Behaviors:

* **Removal of redundant upgrade logic**: Simplified the `UpgradeBehavior` by removing detailed resource checks, delegating resource validation to the new `setting` phase logic in the agent. (`src/AI/agent/behaviors.py`, [src/AI/agent/behaviors.pyL33-L52](diffhunk://#diff-2d43c871009ca8754ed980abd9304a4723cd4ac97351dce70a2fb8d562fc7678L33-L52))
* **Implementation of `DropEveryMineralsBehavior`**: Added a new behavior to drop all minerals except food, facilitating resource management during the `setting` phase. (`src/AI/agent/behaviors.py`, [src/AI/agent/behaviors.pyR139-R153](diffhunk://#diff-2d43c871009ca8754ed980abd9304a4723cd4ac97351dce70a2fb8d562fc7678R139-R153))

### Decision Management System Overhaul:

* **Dynamic decision mapping**: Replaced hardcoded phase-role logic with a dynamic `decisions` dictionary that maps phases and roles to specific behaviors. This simplifies the `take_action` method and improves scalability for future updates. (`src/AI/agent/decisionManager.py`, [[1]](diffhunk://#diff-912057b5391b31c23dfe0b8779ab9ed516ca5b8254900e74de161f2e5594d62bR20-R31) [[2]](diffhunk://#diff-912057b5391b31c23dfe0b8779ab9ed516ca5b8254900e74de161f2e5594d62bL58-R47)