### PR TITLE
[PR] pull request for issue #195 UI afficher la victoire en fin de partie

### DIFF
--- a/libs/RaylibCPP/font/Text3D.cpp
+++ b/libs/RaylibCPP/font/Text3D.cpp
@@ -43,7 +43,6 @@ void Text3D::DrawTextWave3D(::Font font, const std::string& text, Vector3 positi
 
 Vector3 Text3D::MeasureTextWave3D(::Font font, const std::string& text,
     float fontSize, float fontSpacing, float lineSpacing) {
-    std::cout << "MeasureTextWave3D: " << text << std::endl;
     return Text3DMeasurement::measureText(font, text, fontSize, fontSpacing, lineSpacing);
 }
 

--- a/src/GUI/renderer/MapRenderer.cpp
+++ b/src/GUI/renderer/MapRenderer.cpp
@@ -58,6 +58,47 @@ void MapRenderer::render() {
             renderTile(x, y, resourceIndex);
         }
     }
+    renderVictoryScreen();
+}
+
+void MapRenderer::renderVictoryScreen() {
+    if (!gameState->isGameEnded())
+        return;
+    auto winningTeam = gameState->getWinningTeam();
+    if (winningTeam.empty())
+        return;
+    std::string text = "Team " + winningTeam + " wins!";
+    int mapWidth = gameState->getMapWidth();
+    int mapHeight = gameState->getMapHeight();
+    float fontSize = 2.0f;
+    float fontSpacing = 1.0f;
+    float lineSpacing = 1.0f;
+    ZappyTypes::Vector3 textSize = graphicsLib->MeasureText3D(text, fontSize, fontSpacing, lineSpacing);
+    float centerX = (mapWidth - 1) / 2.0f - textSize.x / 2.0f;
+    float centerZ = (mapHeight - 1) / 2.0f - textSize.z / 2.0f;
+    // toyute les couleurs pour chaque lettre
+    std::vector<ZappyTypes::Color> colors = {
+        {255, 0, 0, 255},
+        {255, 165, 0, 255},
+        {255, 255, 0, 255},
+        {0, 255, 0, 255},
+        {0, 0, 255, 255},
+        {75, 0, 130, 255},
+        {148, 0, 211, 255},
+        {255, 20, 147, 255},
+        {0, 255, 255, 255},
+        {255, 105, 180, 255}
+    };
+    float currentX = centerX;
+    for (size_t i = 0; i < text.length(); ++i) {
+        char c = text[i];
+        ZappyTypes::Color color = colors[i % colors.size()];
+        std::string singleChar(1, c);
+        ZappyTypes::Vector3 charPosition = {currentX, 5.0f, centerZ};
+        graphicsLib->DrawText3D(singleChar, charPosition, fontSize, fontSpacing, lineSpacing, true, color);
+        ZappyTypes::Vector3 charSize = graphicsLib->MeasureText3D(singleChar, fontSize, fontSpacing, lineSpacing);
+        currentX += charSize.x + fontSpacing;
+    }
 }
 
 void MapRenderer::setTileRenderStrategy(std::shared_ptr<ITileRenderStrategy> strategy) {

--- a/src/GUI/renderer/MapRenderer.cpp
+++ b/src/GUI/renderer/MapRenderer.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <memory>
 #include <string>
+#include <vector>
 #include "MapRenderer.hpp"
 #include "strategies/TileRenderStrategyFactory.hpp"
 #include "../gameController/GameState.hpp"

--- a/src/GUI/renderer/MapRenderer.hpp
+++ b/src/GUI/renderer/MapRenderer.hpp
@@ -110,6 +110,7 @@ private:
      * @return La couleur calculée
      */
     ZappyTypes::Color calculateTileColor(int x, int y);
+    void renderVictoryScreen();
 };
 
 } // namespace Zappy


### PR DESCRIPTION
This pull request introduces a new feature to display a victory screen in the game and includes minor cleanup and enhancements. The most important changes involve adding the `renderVictoryScreen` method in `MapRenderer` and integrating it into the rendering pipeline. Additionally, a debug log was removed from `Text3D.cpp`.

### Victory Screen Feature:

* [`src/GUI/renderer/MapRenderer.cpp`](diffhunk://#diff-9e2bee33178823d19b6f35c08319e533b8971236be45fdceace6a229619c7b06R62-R102): Added the `renderVictoryScreen` method to display a victory message in 3D text with colorful letters when the game ends. The method calculates the position of the text based on the map dimensions and uses a predefined set of colors for each letter.
* [`src/GUI/renderer/MapRenderer.hpp`](diffhunk://#diff-28e7b161e2cf90d2ef764813569ae0930ec34fa3287680c515ab98ff61c6d2b7R113): Declared the `renderVictoryScreen` method in the `MapRenderer` class.

### Code Cleanup:

* [`libs/RaylibCPP/font/Text3D.cpp`](diffhunk://#diff-57a747306e125d7a814341647e5a60daa27491c7758613a83752d8032a570393L46): Removed a debug log statement from the `MeasureTextWave3D` method to clean up the code.

### Dependency Update:

* [`src/GUI/renderer/MapRenderer.cpp`](diffhunk://#diff-9e2bee33178823d19b6f35c08319e533b8971236be45fdceace6a229619c7b06R12): Added `#include <vector>` to support the use of `std::vector` in the `renderVictoryScreen` method.