### PR TITLE
[PR](Write buffer): Added write buffer and  made it work with current implementation

### DIFF
--- a/src/Server/command/broadcast.c
+++ b/src/Server/command/broadcast.c
@@ -115,7 +115,7 @@ static int send_broadcast_to_client(server_t *server, client_t *sender,
         sender->player->pos_y, server->parsed_info->height);
     direction = calculate_direction(receiver, source_rel_x, source_rel_y);
     snprintf(response, res_size, "message %d, %s\n", direction, message);
-    write_command_output(receiver->client_fd, response);
+    write_command_output_buffer(receiver, response);
     free(response);
     return 0;
 }
@@ -171,10 +171,10 @@ void broadcast(server_t *server, client_t *user, char **buffer)
     client_t *current;
 
     if (!user || !user->player || !buffer || arr_len(buffer) < 2)
-        return write_command_output(user->client_fd, "ko\n");
+        return write_command_output_buffer(user, "ko\n");
     message = build_broadcast_message(buffer);
     if (!message)
-        return write_command_output(user->client_fd, "ko\n");
+        return write_command_output_buffer(user, "ko\n");
     current = server->client;
     if (current)
         current = current->next;
@@ -183,8 +183,8 @@ void broadcast(server_t *server, client_t *user, char **buffer)
         if (current->player && current != user && current->type != GRAPHICAL)
             temp = send_broadcast_to_client(server, user, current, message);
         if (temp == 84)
-            return write_command_output(user->client_fd, "ko\n");
+            return write_command_output_buffer(user, "ko\n");
     }
     free(message);
-    write_command_output(user->client_fd, "ok\n");
+    write_command_output_buffer(user, "ok\n");
 }

--- a/src/Server/command/connect_nbr.c
+++ b/src/Server/command/connect_nbr.c
@@ -31,7 +31,7 @@ static void format_response(int available_slots, client_t *client)
     char *response = malloc(sizeof(char) * res_size);
 
     snprintf(response, res_size, "%d\n", available_slots);
-    write_command_output(client->client_fd, response);
+    write_command_output_buffer(client, response);
     free(response);
 }
 
@@ -51,7 +51,7 @@ void connect_nbr(server_t *server, client_t *client, char **buffer)
 
     if (!client || !client->player || !client->player->team_name ||
         arr_len(buffer) != 1) {
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
         return;
     }
     available_slots = connect_nbr_srv(server, client->player->team_name);

--- a/src/Server/command/eject.c
+++ b/src/Server/command/eject.c
@@ -84,7 +84,7 @@ static void push_single_client(server_t *server,
     tmp->player->pos_y = new_y;
     tile_add_player(&server->map[new_y][new_x], tmp->client_id);
     send_ppo_command(server, tmp->client_id);
-    write_command_output(tmp->client_fd, msg);
+    write_command_output_buffer(tmp, msg);
 }
 
 int push_client(server_t *server, client_t *client, float x, float y)
@@ -131,11 +131,11 @@ void eject(server_t *server, client_t *client, char **buffer)
     float y = 0;
 
     if (!client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     convert_rotation_to_vector(client, &x, &y);
     if (push_client(server, client, x, y) == 84)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     push_eggs(server, client->player->pos_x, client->player->pos_y);
     command_pex(server, client);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/finish_incantation.c
+++ b/src/Server/command/finish_incantation.c
@@ -14,7 +14,7 @@
 static void handle_incantation_failure(client_t *client)
 {
     client->player->incantation_leader_id = -1;
-    write_command_output(client->client_fd, "ko\n");
+    write_command_output_buffer(client, "ko\n");
 }
 
 static bool remove_resources(tile_t *tile, int level)
@@ -72,7 +72,7 @@ static void handle_incantation_success(client_t *client,
         remove_resources(tile, old_level + 1);
     client->player->incantation_leader_id = -1;
     sprintf(level_str, "Current level: %d\n", client->player->level);
-    write_command_output(client->client_fd, level_str);
+    write_command_output_buffer(client, level_str);
     free(level_str);
     if (client->player->level == 8)
         check_win(client, server);

--- a/src/Server/command/fork.c
+++ b/src/Server/command/fork.c
@@ -30,17 +30,17 @@ void fork_c(server_t *server, client_t *client, char **buffer)
     int egg_id;
 
     if (!client || !client->player || arr_len(buffer) != 1) {
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
         return;
     }
     egg_id = get_next_egg_id(server);
     new_egg = create_egg(egg_id, client->player->pos_x, client->player->pos_y,
         client->player->team_name);
     if (!new_egg) {
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
         return;
     }
     add_egg(server, new_egg);
     send_enw_command(server, client, egg_id);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/forward.c
+++ b/src/Server/command/forward.c
@@ -44,17 +44,17 @@ static void change_map_pos(server_t *server, client_t *client)
 void forward(server_t *server, client_t *client, char **buffer)
 {
     if (!client || !client->player || arr_len(buffer) != 1) {
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
         return;
     }
     if (client->player->rotation != UP && client->player->rotation != DOWN
         && client->player->rotation != LEFT
         && client->player->rotation != RIGHT) {
         perror("Unexpected forward rotation");
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
         return;
     }
     change_map_pos(server, client);
     send_ppo_command(server, client->client_id);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/inventory.c
+++ b/src/Server/command/inventory.c
@@ -16,8 +16,8 @@ void inventory(server_t *server, client_t *client, char **buffer)
     char *content;
 
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     content = get_inventory_content(client->player);
-    write_command_output(client->client_fd, content);
+    write_command_output_buffer(client, content);
     free(content);
 }

--- a/src/Server/command/left.c
+++ b/src/Server/command/left.c
@@ -32,14 +32,14 @@ static void change_rot(client_t *client)
 void left(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     if (client->player->rotation != RIGHT && client->player->rotation != DOWN
         && client->player->rotation != LEFT
         && client->player->rotation != UP) {
         perror("Unexpected left rotation");
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     }
     change_rot(client);
     send_ppo_command(server, client->client_id);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/look.c
+++ b/src/Server/command/look.c
@@ -117,14 +117,14 @@ void look(server_t *server, client_t *user, char **buffer)
     char *res;
 
     if (!server || !user || !user->player || arr_len(buffer) != 1)
-        return write_command_output(user->client_fd, "ko\n");
+        return write_command_output_buffer(user, "ko\n");
     total_len = get_total_size(&level_tiles, user, server);
     if (total_len == (size_t)-1 || !level_tiles)
-        return write_command_output(user->client_fd, "ko\n");
+        return write_command_output_buffer(user, "ko\n");
     res = format_look(total_len, level_tiles, user);
     if (!res)
-        return write_command_output(user->client_fd, "ko\n");
+        return write_command_output_buffer(user, "ko\n");
     free(level_tiles);
-    write_command_output(user->client_fd, res);
+    write_command_output_buffer(user, res);
     free(res);
 }

--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -88,13 +88,13 @@ static void send_info_new_client(server_t *server, client_t *user)
     tmp_string = malloc(len1 + 1);
     sprintf(tmp_string, "%d\n", connect_nbr_srv(server,
         user->player->team_name));
-    write_command_output(user->client_fd, tmp_string);
+    write_command_output_buffer(user, tmp_string);
     free(tmp_string);
     tmp_string = malloc(len2 + 1);
     sprintf(tmp_string, "%d %d\n",
         server->parsed_info->width,
         server->parsed_info->height);
-    write_command_output(user->client_fd, tmp_string);
+    write_command_output_buffer(user, tmp_string);
     free(tmp_string);
     send_pnw_command_to_all(server, user);
 }
@@ -114,9 +114,9 @@ void execute_com(server_t *server, client_t *user, char *buffer)
     }
     if (!find_and_execute(server, user, buffer)){
         if (user->is_fully_connected && user->type == GRAPHICAL)
-            return write_command_output(user->client_fd, "suc\n");
+            return write_command_output_buffer(user, "suc\n");
         if (user->is_fully_connected)
-            write_command_output(user->client_fd, "ko\n");
+            write_command_output_buffer(user, "ko\n");
     }
 }
 

--- a/src/Server/command/parse_command_utils.c
+++ b/src/Server/command/parse_command_utils.c
@@ -147,3 +147,12 @@ void write_command_output(int client_fd, char *msg)
     pfd.events = POLLOUT;
     write_with_poll(client_fd, &pfd, msg, strlen(msg));
 }
+
+void write_command_output_buffer(client_t *client, char *msg)
+{
+    if (!client || !validate_client_fd(client->client_fd))
+        return;
+    if (add_string_to_write_buffer(&client->write_buffer, msg) == -1)
+        return write_command_output(client->client_fd, msg);
+    client->need_write = true;
+}

--- a/src/Server/command/parse_command_utils_bis.c
+++ b/src/Server/command/parse_command_utils_bis.c
@@ -71,10 +71,43 @@ static bool is_valid_team_name(char *team_name, server_t *server,
     return false;
 }
 
+int add_string_to_write_buffer(circular_buffer_t *cb, char *msg)
+{
+    size_t len = strlen(msg);
+
+    for (size_t i = 0; i < len; i++) {
+        if (add_to_circular_buffer(cb, msg[i]) == -1)
+            return -1;
+    }
+    return 0;
+}
+
+void flush_client_write_buffer(client_t *client)
+{
+    int available = client->write_buffer.count;
+    char *temp;
+
+    if (!client || client->write_buffer.count == 0)
+        return;
+    temp = malloc(sizeof(char) * (available + 1));
+    if (!temp)
+        return;
+    for (int i = 0; i < available; i++) {
+        temp[i] = client->write_buffer.buffer[client->write_buffer.start];
+        client->write_buffer.start =
+            (client->write_buffer.start + 1) % BUFFER_SIZE;
+        client->write_buffer.count--;
+    }
+    temp[available] = '\0';
+    write_command_output(client->client_fd, temp);
+    client->need_write = false;
+    free(temp);
+}
+
 bool can_connect(server_t *server, client_t *user, char *buffer)
 {
     if (!is_valid_team_name(buffer, server, user)){
-        write_command_output(user->client_fd, "ko\n");
+        write_command_output_buffer(user, "ko\n");
         return false;
     }
     if (user->type != GRAPHICAL &&
@@ -83,7 +116,7 @@ bool can_connect(server_t *server, client_t *user, char *buffer)
             free(user->player->team_name);
             user->player->team_name = NULL;
         }
-        write_command_output(user->client_fd, "ko\n");
+        write_command_output_buffer(user, "ko\n");
         return false;
     }
     return true;

--- a/src/Server/command/right.c
+++ b/src/Server/command/right.c
@@ -32,14 +32,14 @@ static void change_rot(client_t *client)
 void right(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     if (client->player->rotation != RIGHT && client->player->rotation != DOWN
         && client->player->rotation != LEFT
         && client->player->rotation != UP) {
         perror("Unexpected right rotation");
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     }
     change_rot(client);
     send_ppo_command(server, client->client_id);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/set_object.c
+++ b/src/Server/command/set_object.c
@@ -16,12 +16,12 @@ void set_object(server_t *server, client_t *client, char **buffer)
     resource_type_t resource_type;
 
     if (!client || !client->player || arr_len(buffer) != 2)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     resource_type = determine_type(buffer[1]);
     if (resource_type == COUNT)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     if (how_many_in_inventory(client->player, resource_type) <= 0)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     remove_item_from_inventory(client->player, resource_type, 1);
     server->map[client->player->pos_y]
         [client->player->pos_x].resources[resource_type]++;
@@ -30,5 +30,5 @@ void set_object(server_t *server, client_t *client, char **buffer)
     send_pin_to_all(server, client);
     send_bct_to_all_graphical_clients(server, client->player->pos_x,
         client->player->pos_y);
-    write_command_output(client->client_fd, "ok\n");
+    write_command_output_buffer(client, "ok\n");
 }

--- a/src/Server/command/start_incantation.c
+++ b/src/Server/command/start_incantation.c
@@ -109,13 +109,13 @@ bool can_start_incantation(server_t *server, client_t *client)
 void start_incantation(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !client->player || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     if (!can_start_incantation(server, client))
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     command_pic(server, client->player->pos_x, client->player->pos_y,
         client->player->level);
     set_busy_all(server, client, 300);
     client->player->is_in_incantation = true;
     client->player->incantation_leader_id = client->client_id;
-    write_command_output(client->client_fd, "Elevation underway\n");
+    write_command_output_buffer(client, "Elevation underway\n");
 }

--- a/src/Server/command/take_object.c
+++ b/src/Server/command/take_object.c
@@ -45,10 +45,10 @@ void take_object(server_t *server, client_t *client, char **buffer)
     resource_type_t type;
 
     if (!server || !client || !client->player || arr_len(buffer) != 2)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     type = determine_type(buffer[1]);
     if (type == COUNT)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     if (server->map[client->player->pos_y]
         [client->player->pos_x].resources[type] > 0) {
         update_resources(server, client, type);
@@ -57,7 +57,7 @@ void take_object(server_t *server, client_t *client, char **buffer)
         send_bct_to_all_graphical_clients(server, client->player->pos_x,
             client->player->pos_y);
         send_pin_to_all(server, client);
-        write_command_output(client->client_fd, "ok\n");
+        write_command_output_buffer(client, "ok\n");
     } else
-        write_command_output(client->client_fd, "ko\n");
+        write_command_output_buffer(client, "ko\n");
 }

--- a/src/Server/graphical_command/command_bct.c
+++ b/src/Server/graphical_command/command_bct.c
@@ -57,7 +57,7 @@ static void send_bct_command(server_t *server, client_t *client, int x, int y)
         return;
     tile = &server->map[y][x];
     buffer = get_buffer_bct_command(x, y, tile);
-    write_command_output(client->client_fd, buffer);
+    write_command_output_buffer(client, buffer);
     free(buffer);
 }
 
@@ -107,7 +107,7 @@ void command_bct(server_t *server, client_t *client, char **buffer)
         x < 0 || y < 0 ||
         y >= server->parsed_info->height ||
         x >= server->parsed_info->width)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     send_bct_command(server, client, x, y);
 }
 
@@ -115,6 +115,6 @@ void command_mtc(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !server->graphical_clients
         || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     send_tile_content_to_one_client(server, client);
 }

--- a/src/Server/graphical_command/command_ebo.c
+++ b/src/Server/graphical_command/command_ebo.c
@@ -23,11 +23,11 @@ void send_ebo_command(server_t *server, int egg_id)
     size = snprintf(NULL, 0, "ebo #%d\n", egg_id);
     buffer = malloc(size + 1);
     if (!buffer)
-        return write_command_output(current->client->client_fd, "ko\n");
+        return write_command_output_buffer(current->client, "ko\n");
     sprintf(buffer, "ebo #%d\n", egg_id);
     current = server->graphical_clients;
     while (current) {
-        write_command_output(current->client->client_fd, buffer);
+        write_command_output_buffer(current->client, buffer);
         current = current->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_edi.c
+++ b/src/Server/graphical_command/command_edi.c
@@ -25,7 +25,7 @@ void send_edi_command(server_t *server, int egg_id)
     snprintf(buffer, size + 1, "edi #%d\n", egg_id);
     graphical_client = server->graphical_clients;
     while (graphical_client) {
-        write_command_output(graphical_client->client->client_fd, buffer);
+        write_command_output_buffer(graphical_client->client, buffer);
         graphical_client = graphical_client->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_enw.c
+++ b/src/Server/graphical_command/command_enw.c
@@ -38,7 +38,7 @@ void send_enw_command(server_t *server, client_t *client, int egg_id)
         return;
     graphical_client = server->graphical_clients;
     while (graphical_client) {
-        write_command_output(graphical_client->client->client_fd, buffer);
+        write_command_output_buffer(graphical_client->client, buffer);
         graphical_client = graphical_client->next;
     }
     free(buffer);
@@ -52,7 +52,7 @@ static void send_enw_command_to_client(client_t *client,
     buffer = get_buffer_for_enw(egg->egg_id, -1,
         egg->pos_x, egg->pos_y);
     if (buffer) {
-        write_command_output(client->client_fd, buffer);
+        write_command_output_buffer(client, buffer);
         free(buffer);
     }
 }

--- a/src/Server/graphical_command/command_msz.c
+++ b/src/Server/graphical_command/command_msz.c
@@ -28,7 +28,7 @@ void send_msz_command(server_t *server, client_t *client)
         return;
     snprintf(buffer, size + 1, "msz %d %d\n",
             server->parsed_info->width, server->parsed_info->height);
-    write_command_output(client->client_fd, buffer);
+    write_command_output_buffer(client, buffer);
     free(buffer);
 }
 
@@ -36,6 +36,6 @@ void command_msz(server_t *server, client_t *client, char **buffer)
 {
     if (!server || !client || !server->graphical_clients ||
         arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     send_msz_command(server, client);
 }

--- a/src/Server/graphical_command/command_pbc.c
+++ b/src/Server/graphical_command/command_pbc.c
@@ -28,7 +28,7 @@ void command_pbc(server_t *server, client_t *client, char *buffer)
     snprintf(msg, size + 1, "pbc #%d %s", client->client_id, buffer);
     graphical_client = server->graphical_clients;
     while (graphical_client) {
-        write_command_output(graphical_client->client->client_fd, msg);
+        write_command_output_buffer(graphical_client->client, msg);
         graphical_client = graphical_client->next;
     }
     free(msg);

--- a/src/Server/graphical_command/command_pdi.c
+++ b/src/Server/graphical_command/command_pdi.c
@@ -25,7 +25,7 @@ void command_pdi(server_t *server, client_t *client)
     sprintf(buffer, "pdi #%d\n", client->client_id);
     graphical_client = server->graphical_clients;
     while (graphical_client != NULL) {
-        write_command_output(graphical_client->client->client_fd,
+        write_command_output_buffer(graphical_client->client,
             buffer);
         graphical_client = graphical_client->next;
     }

--- a/src/Server/graphical_command/command_pdr.c
+++ b/src/Server/graphical_command/command_pdr.c
@@ -21,11 +21,11 @@ void command_pdr(server_t *server, client_t *client,
     size = snprintf(NULL, 0, "pdr #%d %d\n", client->client_id, resource_type);
     buffer = malloc(size + 1);
     if (buffer == NULL)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     sprintf(buffer, "pdr #%d %d\n", client->client_id, resource_type);
     graphical_client = server->graphical_clients;
     while (graphical_client != NULL) {
-        write_command_output(graphical_client->client->client_fd, buffer);
+        write_command_output_buffer(graphical_client->client, buffer);
         graphical_client = graphical_client->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_pex.c
+++ b/src/Server/graphical_command/command_pex.c
@@ -20,11 +20,11 @@ void command_pex(server_t *server, client_t *client)
     size = snprintf(NULL, 0, "pex #%d\n", client->client_id);
     buffer = malloc(size + 1);
     if (buffer == NULL)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     sprintf(buffer, "pex #%d\n", client->client_id);
     graphical_client = server->graphical_clients;
     while (graphical_client != NULL) {
-        write_command_output(graphical_client->client->client_fd,
+        write_command_output_buffer(graphical_client->client,
             buffer);
         graphical_client = graphical_client->next;
     }

--- a/src/Server/graphical_command/command_pfk.c
+++ b/src/Server/graphical_command/command_pfk.c
@@ -20,11 +20,11 @@ void command_pfk(server_t *server, client_t *client)
     size = snprintf(NULL, 0, "pfk #%d\n", client->client_id);
     buffer = malloc(size + 1);
     if (buffer == NULL)
-        return write_command_output(client->client_fd, "ko\n");
+        return write_command_output_buffer(client, "ko\n");
     sprintf(buffer, "pfk #%d\n", client->client_id);
     graphical_client = server->graphical_clients;
     while (graphical_client != NULL) {
-        write_command_output(graphical_client->client->client_fd, buffer);
+        write_command_output_buffer(graphical_client->client, buffer);
         graphical_client = graphical_client->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_pgt.c
+++ b/src/Server/graphical_command/command_pgt.c
@@ -25,7 +25,7 @@ void command_pgt(server_t *server, client_t *client,
     sprintf(buffer, "pgt #%d %d\n", client->client_id, resource_type);
     graphical_client = server->graphical_clients;
     while (graphical_client != NULL) {
-        write_command_output(graphical_client->client->client_fd, buffer);
+        write_command_output_buffer(graphical_client->client, buffer);
         graphical_client = graphical_client->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_pic.c
+++ b/src/Server/graphical_command/command_pic.c
@@ -50,7 +50,7 @@ void command_pic(server_t *server, int x, int y, int level)
         return;
     current = server->graphical_clients;
     while (current) {
-        write_command_output(current->client->client_fd, buffer);
+        write_command_output_buffer(current->client, buffer);
         current = current->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_pie.c
+++ b/src/Server/graphical_command/command_pie.c
@@ -37,7 +37,7 @@ void command_pie(server_t *server, int x, int y, int result)
         return;
     current = server->client;
     while (current) {
-        write_command_output(current->client_fd, buffer);
+        write_command_output_buffer(current, buffer);
         current = current->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_pin.c
+++ b/src/Server/graphical_command/command_pin.c
@@ -59,7 +59,7 @@ void send_pin_command(server_t *server, client_t *client, client_t *recipient)
     (void)server;
     if (!buffer || !server->graphical_clients)
         return;
-    write_command_output(recipient->client_fd, buffer);
+    write_command_output_buffer(recipient, buffer);
     free(buffer);
 }
 
@@ -83,10 +83,10 @@ void command_pin(server_t *server, client_t *client, char **buffer)
     if (!server || !client || !server->graphical_clients ||
         arr_len(buffer) != 2 ||
         sscanf(buffer[1], "#%d\n", &id) != 1 || id < 0)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     recipient = find_client_by_id(server, id);
     if (!recipient || recipient->type != AI) {
-        write_command_output(client->client_fd, "sbp\n");
+        write_command_output_buffer(client, "sbp\n");
         return;
     }
     send_pin_command(server, recipient, client);

--- a/src/Server/graphical_command/command_plv.c
+++ b/src/Server/graphical_command/command_plv.c
@@ -30,7 +30,7 @@ void send_plv_command(server_t *server, client_t *client, client_t *recipient)
     snprintf(buffer, size + 1, "plv #%d %d\n",
             client->client_id,
             client->player->level);
-    write_command_output(recipient->client_fd, buffer);
+    write_command_output_buffer(recipient, buffer);
     free(buffer);
 }
 
@@ -56,10 +56,10 @@ void command_plv(server_t *server, client_t *client, char **buffer)
     if (!server || !client || !buffer ||
         !server->graphical_clients || arr_len(buffer) != 2 ||
         sscanf(buffer[1], "#%d\n", &id) != 1)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     recipient = find_client_by_id(server, id);
     if (!recipient || recipient->type != AI) {
-        write_command_output(client->client_fd, "sbp\n");
+        write_command_output_buffer(client, "sbp\n");
         return;
     }
     send_plv_command(server, recipient, client);

--- a/src/Server/graphical_command/command_pnw.c
+++ b/src/Server/graphical_command/command_pnw.c
@@ -43,7 +43,7 @@ void send_pnw_command(server_t *server, client_t *client, client_t *recipient)
             client->player->rotation,
             client->player->level,
             client->player->team_name);
-    write_command_output(recipient->client_fd, buffer);
+    write_command_output_buffer(recipient, buffer);
     free(buffer);
 }
 

--- a/src/Server/graphical_command/command_ppo.c
+++ b/src/Server/graphical_command/command_ppo.c
@@ -56,10 +56,10 @@ bool send_ppo_command(server_t *server, int id)
     if (!tmp || !tmp->player)
         return false;
     buffer = get_ppo_buffer(tmp);
-    for (client_t *cur = server->client; cur != NULL; cur = cur->next) {
-        if (cur->type == GRAPHICAL && cur->is_fully_connected) {
-            write_command_output(cur->client_fd, buffer);
-        }
+    for (client_t *current = server->client;
+            current != NULL; current = current->next) {
+        if (current->type == GRAPHICAL && current->is_fully_connected)
+            write_command_output_buffer(current, buffer);
     }
     free(buffer);
     return true;
@@ -73,6 +73,6 @@ void command_ppo(server_t *server, client_t *client, char **buffer)
         arr_len(buffer) != 2 || sscanf(buffer[1], "#%d\n", &id) != 1 ||
         id < 0 || !find_client_by_id(server, id) ||
         !send_ppo_command(server, id)) {
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     }
 }

--- a/src/Server/graphical_command/command_seg.c
+++ b/src/Server/graphical_command/command_seg.c
@@ -27,7 +27,7 @@ void command_seg(server_t *server, const char *team_name)
     snprintf(buffer, size + 1, "seg %s\n", team_name);
     current = server->graphical_clients;
     while (current) {
-        write_command_output(current->client->client_fd, buffer);
+        write_command_output_buffer(current->client, buffer);
         current = current->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_sgt.c
+++ b/src/Server/graphical_command/command_sgt.c
@@ -20,13 +20,13 @@ void command_sgt(server_t *server, client_t *client, char **buffer)
 
     if (!server || !client || !server->graphical_clients ||
         arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "spb\n");
+        return write_command_output_buffer(client, "spb\n");
     tmp = NULL;
     size = snprintf(NULL, 0, "sgt %d\n", server->parsed_info->frequence);
     tmp = malloc(size + 1);
     if (!tmp)
         return;
     snprintf(tmp, size + 1, "sgt %d\n", server->parsed_info->frequence);
-    write_command_output(client->client_fd, tmp);
+    write_command_output_buffer(client, tmp);
     free(tmp);
 }

--- a/src/Server/graphical_command/command_smg.c
+++ b/src/Server/graphical_command/command_smg.c
@@ -28,7 +28,7 @@ void send_smg_command(server_t *server, const char *msg)
     snprintf(buffer, size + 1, "smg %s\n", msg);
     current = server->graphical_clients;
     while (current) {
-        write_command_output(current->client->client_fd, buffer);
+        write_command_output_buffer(current->client, buffer);
         current = current->next;
     }
     free(buffer);

--- a/src/Server/graphical_command/command_sst.c
+++ b/src/Server/graphical_command/command_sst.c
@@ -42,15 +42,15 @@ void command_sst(server_t *server, client_t *client, char **buffer)
 
     if (!buffer || client->type != GRAPHICAL || !server->graphical_clients ||
         arr_len(buffer) != 2)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     time = get_time_from_buffer(buffer[1]);
     if (time <= 0)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     tmp_buffer = get_buffer_sst(time);
     server->parsed_info->frequence = time;
     graphical_client = server->graphical_clients;
     while (graphical_client) {
-        write_command_output(graphical_client->client->client_fd,
+        write_command_output_buffer(graphical_client->client,
             tmp_buffer);
         graphical_client = graphical_client->next;
     }

--- a/src/Server/graphical_command/command_tna.c
+++ b/src/Server/graphical_command/command_tna.c
@@ -26,7 +26,7 @@ static void send_one_tna_command(server_t *server, client_t *client,
     if (!buffer)
         return;
     snprintf(buffer, size + 1, "tna %s\n", team);
-    write_command_output(client->client_fd, buffer);
+    write_command_output_buffer(client, buffer);
     free(buffer);
 }
 
@@ -44,6 +44,6 @@ void command_tna(server_t *server, client_t *client, char **buffer)
     if (!server || !client || !buffer || !server->parsed_info ||
         !server->parsed_info->names || !server->graphical_clients
         || arr_len(buffer) != 1)
-        return write_command_output(client->client_fd, "sbp\n");
+        return write_command_output_buffer(client, "sbp\n");
     send_tna_command(server, client);
 }

--- a/src/Server/include/client.h
+++ b/src/Server/include/client.h
@@ -28,10 +28,12 @@ typedef struct client_s {
     struct pollfd *client_poll;
     struct sockaddr_in *client_add;
     circular_buffer_t read_buffer;
+    circular_buffer_t write_buffer;
     player_t *player;
-    struct client_s *next;
     bool is_fully_connected;
     enum client_type_e type;
+    bool need_write;
+    struct client_s *next;
 } client_t;
 
 void send_message_to_all_graphic(server_t *server, char *message);

--- a/src/Server/include/command.h
+++ b/src/Server/include/command.h
@@ -41,6 +41,7 @@ void broadcast(server_t *server, client_t *user, char **buffer);
 int connect_nbr_srv(server_t *server, char *team);
 bool can_connect(server_t *server, client_t *user, char *buffer);
 client_t *find_client_by_id(server_t *server, int id);
+void write_command_output_buffer(client_t *client, char *msg);
 
 // Death and starvation management functions
 void handle_player_death(server_t *server, client_t *client);

--- a/src/Server/include/server.h
+++ b/src/Server/include/server.h
@@ -165,5 +165,8 @@ void free_all(server_t *server, parsing_info_t *parsed_info);
 int count_team(server_t *n_server);
 
 void init_struct(client_t *new_c);
+int add_string_to_write_buffer(circular_buffer_t *cb, char *msg);
+void flush_client_write_buffer(client_t *client);
+client_t *find_client_by_socket(server_t *server, int socket_fd);
 
 #endif /* !SERVER_H_ */

--- a/src/Server/network/connection_utils.c
+++ b/src/Server/network/connection_utils.c
@@ -37,12 +37,27 @@ static void create_server_egg(server_t *n_server, int egg_id, int i)
     add_egg(n_server, n_egg);
 }
 
+client_t *find_client_by_socket(server_t *server, int socket_fd)
+{
+    client_t *temp = server->client;
+
+    if (temp && temp->client_fd == server->s_fd)
+        temp = temp->next;
+    while (temp) {
+        if (temp->client_fd == socket_fd)
+            return temp;
+        temp = temp->next;
+    }
+    return NULL;
+}
+
 void init_struct(client_t *new_c)
 {
     init_player(new_c->player, NULL);
     if (!new_c->player)
         return;
     init_circular_buffer(&new_c->read_buffer);
+    init_circular_buffer(&new_c->write_buffer);
 }
 
 void init_server_eggs(server_t *n_server)

--- a/src/Server/network/graphical_client.c
+++ b/src/Server/network/graphical_client.c
@@ -76,7 +76,7 @@ void send_message_to_all_graphic(server_t *server, char *message)
 
     while (current) {
         if (current->client && current->client->client_fd != -1)
-            write_command_output(current->client->client_fd, message);
+            write_command_output_buffer(current->client, message);
         current = current->next;
     }
 }

--- a/src/Server/network/server_run.c
+++ b/src/Server/network/server_run.c
@@ -14,21 +14,6 @@
 #include <stdlib.h>
 #include <sys/time.h>
 
-client_t *find_client_by_socket(server_t *server, int socket_fd)
-{
-    client_t *temp = server->client;
-
-    if (temp && temp->client_fd == server->s_fd)
-        temp = temp->next;
-    while (temp) {
-        if (temp->client_fd == socket_fd)
-            return temp;
-        temp = temp->next;
-    }
-    printf("Error: Could not find client for socket %d\n", socket_fd);
-    return NULL;
-}
-
 static void new_connection(server_t *server)
 {
     struct sockaddr_in client_addr;
@@ -54,18 +39,29 @@ static void check_new_connection(server_t *server)
         new_connection(server);
 }
 
+static void pollin_pollout_client(client_t *temp,
+    server_t *server, int temp_fd)
+{
+    if (temp->client_poll->revents & POLLIN)
+                get_message(server, temp);
+    if (find_client_by_socket(server, temp_fd) != NULL &&
+        temp->client_poll->revents & POLLOUT && temp->need_write)
+        flush_client_write_buffer(temp);
+}
+
 static void check_client_message(server_t *server)
 {
     client_t *temp = server->client;
     client_t *next = NULL;
+    int temp_fd;
 
     if (temp != NULL)
         temp = temp->next;
     while (temp != NULL) {
         next = temp->next;
-        if (temp->client_poll != NULL && temp->client_poll->revents != 0
-            && (temp->client_poll->revents & POLLIN))
-                get_message(server, temp);
+        temp_fd = temp->client_fd;
+        if (temp->client_poll != NULL && temp->client_poll->revents != 0)
+            pollin_pollout_client(temp, server, temp_fd);
         temp = next;
     }
 }
@@ -92,13 +88,15 @@ static void smart_polling(client_t *current, poll_manager_t *poll_mana,
     server_t *server, int i)
 {
     if (current->type == GRAPHICAL) {
-        poll_mana->fds[i].events = POLLIN;
+        poll_mana->fds[i].events |= POLLIN;
     } else if (current->player &&
         current->player->busy_until > server->current_tick &&
         current->player->queue_size >= 10) {
         poll_mana->fds[i].events = 0;
     } else
-        poll_mana->fds[i].events = POLLIN;
+        poll_mana->fds[i].events |= POLLIN;
+    if (current->need_write)
+        poll_mana->fds[i].events |= POLLOUT;
 }
 
 static void fill_poll_array(server_t *server, poll_manager_t *poll_mana)


### PR DESCRIPTION
This pull request introduces a refactor across multiple server command files to replace direct socket writes (`write_command_output`) with buffered writes (`write_command_output_buffer`). The goal is to improve the handling of client output by leveraging a circular buffer for queued writes. Additionally, new utility functions for managing the write buffer were added to ensure robust and efficient output processing.

### Refactor to use buffered writes:
* Replaced `write_command_output` with `write_command_output_buffer` in various command implementations, such as `broadcast`, `connect_nbr`, `eject`, `finish_incantation`, `fork_c`, `forward`, `inventory`, `left`, `look`, `right`, `set_object`, `start_incantation`, and `take_object` commands. This change ensures that client responses are queued in the circular buffer before being sent. [[1]](diffhunk://#diff-ca778857c282081d9222ca724ebe62cd2d3c73e98cc23e02f85b9e636239c06eL118-R118) [[2]](diffhunk://#diff-97de128cad7eb6faa567453bdea94b62e037ead66ae4d3271334126f69d36c03L34-R34) [[3]](diffhunk://#diff-33b28f816c6b4580db2f941cd13af8298d2f6ffa3cdf91c0bd3a6ab074cecfd1L87-R87) [[4]](diffhunk://#diff-1a1f4976fbb0745568ff8336fd30987e3cc7f9f0cb4e679b3b91f55561d4e3b6L17-R17) [[5]](diffhunk://#diff-8e22b6fe5bbd66a102c64f72ddfab4360dc0483fdb34f1972a9d23dfd517545dL33-R45) [[6]](diffhunk://#diff-df2e63f21dc69fd6433b2e1d576c2904a2626d522b6e2ddb059253f2fcad2645L47-R59) [[7]](diffhunk://#diff-8c71dc2f3952a6bb3c2383f865102cd85de2214bb37a99a091813cca720bc8aaL19-R21) [[8]](diffhunk://#diff-04b255af7859b5e2fe22f706d11cb4d3c01551076d89253b16e16f3f0c8b4e93L35-R44) [[9]](diffhunk://#diff-135fcbe5ef3c4370ce0b8364038a55bddf1084c43d5383fd72dc46135430c35eL120-R128) [[10]](diffhunk://#diff-065075fd20e79a477c40a00610588558c3b2a236d89c8593dff662a50cde0c0bL35-R44) [[11]](diffhunk://#diff-75df72d540330a63d35729256acfb58912a4937a860eafb8f815b307a2a74316L19-R24) [[12]](diffhunk://#diff-51d16d56507a268bd7a70c129929d7182d98cdb1104e2d999d43688b74df533aL112-R120) [[13]](diffhunk://#diff-41839c255d33b5140967a6b95f444b5438fdf113f4a6230a54325ee6510684f2L48-R51)

### Addition of new utility functions:
* Added `write_command_output_buffer` to handle buffered writes, which checks client validity, validates the file descriptor, and queues the message in the circular buffer. If the buffer operation fails, it falls back to direct socket writes.
* Introduced `add_string_to_write_buffer` to add strings to the circular buffer and `flush_client_write_buffer` to flush the buffer contents to the client socket. These functions enhance the modularity and reliability of output handling. [[1]](diffhunk://#diff-f0658ae210a9a45e2291279f414c4677fd0841fc99994edc326adfcc119a15dfR74-R110) [[2]](diffhunk://#diff-f0658ae210a9a45e2291279f414c4677fd0841fc99994edc326adfcc119a15dfL86-R119)

### Graphical commands refactor:
* Updated graphical command implementations (`command_bct`, `command_mtc`) to use buffered writes, ensuring consistency across all client output mechanisms. [[1]](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefL60-R60) [[2]](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefL110-R118)

These changes collectively improve server-client communication by introducing a more robust and scalable output handling mechanism.