### PR TITLE
[PR](Bug): Fixed bug in GUI command

### DIFF
--- a/src/Server/command/parse_command.c
+++ b/src/Server/command/parse_command.c
@@ -18,13 +18,13 @@ command_data_t get_command_data(void)
 {
     static const char *comm_char[] = {"Forward", "Right", "Left",
         "Inventory", "Look", "Eject", "Connect_nbr", "Take", "Set",
-        "Incantation", "Fork", "Broadcast", "msz", "bct", "mtc",
+        "Incantation", "Fork", "Broadcast", "msz", "bct", "mct",
         "tna", "ppo", "plv", "pin", "sgt", "sst", NULL};
     static void (*comm_func[])(game_t *, zappy_client_t *, zappy_client_t *,
         char **) =
         {forward, right, left, inventory, look, eject,
         connect_nbr, take_object, set_object, start_incantation,
-        fork_c, broadcast, command_msz, command_bct, command_mtc,
+        fork_c, broadcast, command_msz, command_bct, command_mct,
         command_tna, command_ppo, command_plv, command_pin,
         command_sgt, command_sst, NULL};
     static int comm_times[] = {7, 7, 7, 1, 7, 7, 0, 7, 7, 300, 42, 7, 0,

--- a/src/Server/graphical_command/command_bct.c
+++ b/src/Server/graphical_command/command_bct.c
@@ -48,7 +48,7 @@ static void send_bct_response(client_t *client, int x, int y, tile_t *tile)
     char *buffer = get_buffer_bct_command(x, y, tile);
 
     if (buffer) {
-        write_command_output_buffer(client, buffer);
+        write_command_output(client, buffer);
         free(buffer);
     }
 }
@@ -115,7 +115,7 @@ void command_bct(game_t *game, zappy_client_t *client,
     send_bct_response(client->client, x, y, &game->map[y][x]);
 }
 
-void command_mtc(game_t *game, zappy_client_t *client,
+void command_mct(game_t *game, zappy_client_t *client,
     zappy_client_t *clients, char **buffer)
 {
     (void)clients;

--- a/src/Server/graphical_command/command_msz.c
+++ b/src/Server/graphical_command/command_msz.c
@@ -27,7 +27,7 @@ void send_msz_command(game_t *game, zappy_client_t *client)
         return;
     snprintf(buffer, size + 1, "msz %d %d\n",
             game->parsed_info->width, game->parsed_info->height);
-    write_command_output_buffer(client->client, buffer);
+    write_command_output(client->client, buffer);
     free(buffer);
 }
 

--- a/src/Server/include/graphical_commands.h
+++ b/src/Server/include/graphical_commands.h
@@ -14,7 +14,7 @@ void command_msz(game_t *game, zappy_client_t *client,
     zappy_client_t *clients, char **buffer);
 void command_bct(game_t *game, zappy_client_t *client,
     zappy_client_t *clients, char **buffer);
-void command_mtc(game_t *game, zappy_client_t *client,
+void command_mct(game_t *game, zappy_client_t *client,
     zappy_client_t *clients, char **buffer);
 void command_tna(game_t *game, zappy_client_t *client,
     zappy_client_t *clients, char **buffer);


### PR DESCRIPTION
This pull request includes updates to improve consistency in naming conventions and refactor function calls for better clarity and maintainability. The most important changes involve renaming the `command_mtc` function to `command_mct` and replacing the `write_command_output_buffer` function with `write_command_output` in multiple files.

### Naming Convention Updates:
* [`src/Server/command/parse_command.c`](diffhunk://#diff-cbe081026b0677d1c393a4e0cabf03dc04ad21572c210d3d255d359d89316df1L21-R27): Renamed `command_mtc` to `command_mct` in the `comm_char` and `comm_func` arrays to ensure consistency with other graphical command naming conventions.
* [`src/Server/graphical_command/command_bct.c`](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefL118-R118): Updated the function name from `command_mtc` to `command_mct` in the `command_mct` function definition.
* [`src/Server/include/graphical_commands.h`](diffhunk://#diff-50aa332841cb19c34283cea8b103aad91deedbd06bb4585669d776effc3552e3L17-R17): Reflected the `command_mtc` to `command_mct` renaming in the function declaration.

### Function Call Refactoring:
* [`src/Server/graphical_command/command_bct.c`](diffhunk://#diff-03f0a1ebb262544c51de441c6a8519bc201bb80fed049e6734547aa8ff4eacefL51-R51): Replaced `write_command_output_buffer` with `write_command_output` in the `send_bct_response` function for more streamlined command output handling.
* [`src/Server/graphical_command/command_msz.c`](diffhunk://#diff-9b1c48e2e18a06c742a55255fdbbbaf5a202513a2271547399392d27ef3e46feL30-R30): Updated `write_command_output_buffer` to `write_command_output` in the `send_msz_command` function to align with the refactored output handling approach.