### PR TITLE
[FIX](Player info): Fixed player info sending where player info were not sent compared to previous versions

### DIFF
--- a/src/Server/graphical_command/command_pnw.c
+++ b/src/Server/graphical_command/command_pnw.c
@@ -80,8 +80,11 @@ void send_all_player_info_to_one_client(game_t *game, zappy_client_t *clients,
         return;
     while (current) {
         if (current->player && current->type == AI &&
-            current->is_fully_connected)
+            current->is_fully_connected){
             send_pnw_command(game, clients, current, recipient);
+            send_pin_command(game, clients, current, recipient);
+            send_plv_command(game, clients, current, recipient);
+        }
         current = current->next;
     }
 }


### PR DESCRIPTION
This pull request enhances the behavior of the `send_all_player_info_to_one_client` function in the `command_pnw.c` file by ensuring additional player information is sent to a client. Specifically, it introduces new commands to provide more comprehensive details about each player.

### Enhancements to player information transmission:

* [`src/Server/graphical_command/command_pnw.c`](diffhunk://#diff-1ef318756dfdab46b81c34fba81239709d3ffc43dafd7324cb15d71d34583398L83-R87): Added calls to `send_pin_command` and `send_plv_command` alongside the existing `send_pnw_command` within the `send_all_player_info_to_one_client` function. These additions ensure that position and level information for AI players who are fully connected are also sent to the recipient client.